### PR TITLE
[HUDI-2705] Metadata Index - Column stats metadata to speed up index lookup - read path PoC

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexGroupedLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexGroupedLookupHandle.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.table.HoodieTable;
@@ -69,7 +70,8 @@ public class HoodieKeyMetaBloomIndexGroupedLookupHandle<T extends HoodieRecordPa
     HoodieTimer timer = new HoodieTimer().startTimer();
 
     Option<ByteBuffer> bloomFilterByteBuffer =
-        hoodieTable.getMetadataTable().getBloomFilter(new FileID(fileName));
+        hoodieTable.getMetadataTable().getBloomFilter(new PartitionID(partitionPathFileIdPair.getLeft()),
+            new FileID(fileName));
     if (!bloomFilterByteBuffer.isPresent()) {
       throw new HoodieIndexException("BloomFilter missing for " + fileName);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexLookupHandle.java
@@ -97,9 +97,11 @@ public class HoodieKeyMetaBloomIndexLookupHandle<T extends HoodieRecordPayload, 
         HoodieTimer timer = new HoodieTimer().startTimer();
         Set<String> fileRowKeys = createNewFileReader().filterRowKeys(new HashSet<>(candidateRecordKeys));
         foundRecordKeys.addAll(fileRowKeys);
-        LOG.debug(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)", filePath,
-            timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
-        LOG.debug("Keys matching for file " + filePath + " => " + foundRecordKeys);
+        if (config.getMetadataConfig().isIndexLookupLoggingEnabled()) {
+          LOG.error(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)", filePath,
+              timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
+          LOG.error("Keys matching for file " + filePath + " => " + foundRecordKeys);
+        }
       }
     } catch (Exception e) {
       throw new HoodieIndexException("Error checking candidate keys against file.", e);
@@ -132,9 +134,12 @@ public class HoodieKeyMetaBloomIndexLookupHandle<T extends HoodieRecordPayload, 
     HoodieBaseFile dataFile = getLatestDataFile();
     List<String> matchingKeys =
         checkCandidatesAgainstFile(hoodieTable.getHadoopConf(), candidateRecordKeys, new Path(dataFile.getPath()));
-    LOG.debug(
-        String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)", totalKeysChecked,
-            candidateRecordKeys.size(), candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+    if (config.getMetadataConfig().isIndexLookupLoggingEnabled()) {
+      LOG.error(
+          String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)",
+              totalKeysChecked,
+              candidateRecordKeys.size(), candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+    }
     return new MetaBloomIndexKeyLookupResult(partitionPathFilePair.getRight(), partitionPathFilePair.getLeft(),
         dataFile.getCommitTime(), matchingKeys);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexLookupHandle.java
@@ -30,6 +30,7 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.table.HoodieTable;
@@ -69,7 +70,8 @@ public class HoodieKeyMetaBloomIndexLookupHandle<T extends HoodieRecordPayload, 
     HoodieTimer timer = new HoodieTimer().startTimer();
 
     Option<ByteBuffer> bloomFilterByteBuffer =
-        hoodieTable.getMetadataTable().getBloomFilter(new FileID(fileName));
+        hoodieTable.getMetadataTable().getBloomFilter(new PartitionID(partitionPathFileIdPair.getLeft()),
+            new FileID(fileName));
     if (!bloomFilterByteBuffer.isPresent()) {
       throw new HoodieIndexException("BloomFilter missing for " + fileName);
     }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexCheckFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexCheckFunction.java
@@ -31,7 +31,6 @@ import org.apache.hudi.io.HoodieKeyMetaBloomIndexLookupHandle.MetaBloomIndexKeyL
 import org.apache.hudi.table.HoodieTable;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.function.Function2;
 import scala.Tuple2;
 
@@ -77,8 +76,6 @@ public class HoodieBloomMetaIndexCheckFunction
 
     @Override
     protected List<MetaBloomIndexKeyLookupResult> computeNext() {
-
-      TaskContext tc = TaskContext.get();
 
       List<MetaBloomIndexKeyLookupResult> ret = new ArrayList<>();
       try {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexColStatFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexColStatFunction.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.avro.model.HoodieColumnStats;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Function performing actual checking of RDD partition containing (fileId, hoodieKeys) against the actual files.
+ */
+public class HoodieBloomMetaIndexColStatFunction
+    implements FlatMapFunction<Iterator<Tuple2<Tuple2<String, String>, HoodieKey>>, Tuple2<Tuple2<String, String>,
+    HoodieKey>> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieBloomMetaIndexColStatFunction.class);
+  private final HoodieTable hoodieTable;
+  private final HoodieWriteConfig config;
+
+  public HoodieBloomMetaIndexColStatFunction(HoodieTable hoodieTable, HoodieWriteConfig config) {
+    this.hoodieTable = hoodieTable;
+    this.config = config;
+  }
+
+  @Override
+  public Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> call(
+      Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tuple2Iterator) throws Exception {
+    Map<String, String> columnKeyHashToFileNameMap = new HashMap<>();
+    Map<String, List<HoodieKey>> columnKeyHashToHoodieKeysMap = new HashMap<>();
+    List<Tuple2<Tuple2<String, String>, HoodieKey>> result = new ArrayList<>();
+
+    while (tuple2Iterator.hasNext()) {
+      final Tuple2<Tuple2<String, String>, HoodieKey> entry = tuple2Iterator.next();
+      final String colStatKeyHash = entry._1._1;
+      final String fileName = entry._1._2;
+      final HoodieKey hoodieKey = entry._2;
+
+      columnKeyHashToHoodieKeysMap.computeIfAbsent(colStatKeyHash, e -> new ArrayList<>()).add(hoodieKey);
+      columnKeyHashToFileNameMap.putIfAbsent(colStatKeyHash, fileName);
+    }
+
+    Map<String, HoodieColumnStats> columnKeyHashToStatMap =
+        hoodieTable.getMetadataTable().getColumnStats(
+            columnKeyHashToHoodieKeysMap.keySet().stream().collect(Collectors.toList()));
+
+    for (Map.Entry<String, String> entry : columnKeyHashToFileNameMap.entrySet()) {
+      ValidationUtils.checkState(columnKeyHashToHoodieKeysMap.containsKey(entry.getKey()));
+      ValidationUtils.checkState(columnKeyHashToStatMap.containsKey(entry.getKey()));
+
+      final String fileName = entry.getValue();
+      final List<HoodieKey> keyList = columnKeyHashToHoodieKeysMap.get(entry.getKey());
+      final HoodieColumnStats keyColumnStat = columnKeyHashToStatMap.get(entry.getKey());
+
+      keyList.forEach(hoodieKey -> {
+        if ((Objects.requireNonNull(keyColumnStat.getRangeLow()).compareTo(hoodieKey.getRecordKey()) <= 0)
+            && (Objects.requireNonNull(keyColumnStat.getRangeHigh()).compareTo(hoodieKey.getRecordKey()) >= 0)) {
+          result.add(new Tuple2<>(new Tuple2<>(FSUtils.getFileId(fileName), fileName), hoodieKey));
+        }
+      });
+    }
+    return result.iterator();
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexGroupedFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexGroupedFunction.java
@@ -130,10 +130,12 @@ public class HoodieBloomMetaIndexGroupedFunction
       List<String> matchingKeys =
           checkCandidatesAgainstFile(candidateRecordKeys, new Path(dataFile.get().getPath()));
 
-      LOG.error(
-          String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)",
-              hoodieKeyList.size(), candidateRecordKeys.size(),
-              candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+      if (config.getMetadataConfig().isIndexLookupLoggingEnabled()) {
+        LOG.error(
+            String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)",
+                hoodieKeyList.size(), candidateRecordKeys.size(),
+                candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+      }
 
       ArrayList<MetaBloomIndexGroupedKeyLookupResult> subList = new ArrayList<>();
       subList.add(new MetaBloomIndexGroupedKeyLookupResult(fileId, partitionPath, dataFile.get().getCommitTime(),
@@ -156,10 +158,12 @@ public class HoodieBloomMetaIndexGroupedFunction
             latestDataFilePath);
         Set<String> fileRowKeys = fileReader.filterRowKeys(new HashSet<>(candidateRecordKeys));
         foundRecordKeys.addAll(fileRowKeys);
-        LOG.debug(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)",
-            latestDataFilePath,
-            timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
-        LOG.debug("Keys matching for file " + latestDataFilePath + " => " + foundRecordKeys);
+        if (config.getMetadataConfig().isIndexLookupLoggingEnabled()) {
+          LOG.error(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)",
+              latestDataFilePath,
+              timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
+          LOG.error("Keys matching for file " + latestDataFilePath + " => " + foundRecordKeys);
+        }
       }
     } catch (Exception e) {
       throw new HoodieIndexException("Error checking candidate keys against file.", e);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/SparkHoodieBloomIndexHelper.java
@@ -23,9 +23,11 @@ import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.ColumnID;
 import org.apache.hudi.common.util.hash.FileID;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaPairRDD;
@@ -68,9 +70,12 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
       HoodieData<ImmutablePair<String, HoodieKey>> fileComparisonPairs,
       Map<String, List<BloomIndexFileInfo>> partitionToFileInfo,
       Map<String, Long> recordsPerPartition) {
+
+    // Pair<fileId, key> => JavaRDD<Tuple2<fileID, key>>
     JavaRDD<Tuple2<String, HoodieKey>> fileComparisonsRDD =
         HoodieJavaRDD.getJavaRDD(fileComparisonPairs)
             .map(pair -> new Tuple2<>(pair.getLeft(), pair.getRight()));
+
     Map<String, Long> comparisonsPerFileGroup = computeComparisonsPerFileGroup(
         config, recordsPerPartition, partitionToFileInfo, fileComparisonsRDD, context);
     int inputParallelism =
@@ -86,37 +91,46 @@ public class SparkHoodieBloomIndexHelper extends BaseHoodieBloomIndexHelper {
       fileComparisonsRDD = fileComparisonsRDD.mapToPair(t -> new Tuple2<>(Pair.of(t._1, t._2.getRecordKey()), t))
           .repartitionAndSortWithinPartitions(partitioner).map(Tuple2::_2);
     } else {
+
+      // Step 1: Transform the fileId to name/hash pairs
       // fileId(uuid part of the file), HoodieKey => file_name, HoodieKey
       fileComparisonsRDD = fileComparisonsRDD.map(entry -> new Tuple2<String, HoodieKey>(
           hoodieTable.getBaseFileOnlyView().getLatestBaseFile(entry._2.getPartitionPath(), entry._1).get().getFileName(),
           entry._2));
 
+      // Step 2: File pruning
+      // Get the mapping of FileId to list of keys that might be available in the file
+      // We need to make use of the column stats instead of the absence of RangeFiltering/ListFiltering
+      // that used to happen at HoodieBloomIndex::explodeRecordsWithFileComparisons()
+      // <<ColStatHash, filename> key>
+      // RDD Tuple2<Tuple2<ColumnIDHash|FileIDHash>, filename>, HoodieKey>
+      JavaRDD<Tuple2<Tuple2<String, String>, HoodieKey>> columnStatHashAndKeyTuple = fileComparisonsRDD.map(entry -> {
+        String fileName = entry._1;
+        String columnName = HoodieRecord.RECORD_KEY_METADATA_FIELD; // this is the only col for index lookup
+        String columnStatKeyHash =
+            new ColumnID(columnName).asBase64EncodedString().concat(new FileID(fileName).asBase64EncodedString());
+        return new Tuple2<Tuple2<String, String>, HoodieKey>(new Tuple2<>(columnStatKeyHash, fileName), entry._2);
+      }).sortBy(entry -> entry._1._1, true, joinParallelism);
+
+      JavaRDD<Tuple2<Tuple2<String, String>, HoodieKey>> colStatFilteredFileNames =
+          columnStatHashAndKeyTuple.mapPartitions(
+              new HoodieBloomMetaIndexColStatFunction(hoodieTable, config), true);
+
+      // Step 3: Sort by file hash
       // <<fileName, hash>, key>
-      JavaRDD<Tuple2<Tuple2<String, String>, HoodieKey>> tempVar =
-          fileComparisonsRDD.map(
-              entry -> new Tuple2<Tuple2<String, String>, HoodieKey>(new Tuple2<>(entry._1,
-                  new FileID(entry._1).asBase64EncodedString()), entry._2)).sortBy(entry -> entry._1._2, true,
-              joinParallelism);
+      JavaRDD<Tuple2<Tuple2<String, String>, HoodieKey>> sortedFileNameHashAndKeyTuples =
+          colStatFilteredFileNames.map(entry -> new Tuple2<Tuple2<String, String>, HoodieKey>(new Tuple2<>(entry._1._2,
+                  new FileID(entry._1._2).asBase64EncodedString()), entry._2))
+              .sortBy(entry -> entry._1._2, true, joinParallelism);
 
-      /*
-      return HoodieJavaPairRDD.of(tempVar.mapPartitionsWithIndex(
-              new HoodieBloomMetaIndexCheckFunction(hoodieTable, config), true)
-          .flatMap(List::iterator).filter(lr -> lr.getMatchingRecordKeys().size() > 0)
-          .flatMapToPair(lookupResult -> lookupResult.getMatchingRecordKeys().stream()
-              .map(recordKey -> new Tuple2<>(new HoodieKey(recordKey, lookupResult.getPartitionPath()),
-                  new HoodieRecordLocation(lookupResult.getBaseInstantTime(), lookupResult.getFileId())))
-              .collect(Collectors.toList()).iterator()));
-      */
-
-      return HoodieJavaPairRDD.of(tempVar.mapPartitionsWithIndex(
+      // Step 4: Use bloom filter to filter and the actual log file to get the record location
+      return HoodieJavaPairRDD.of(sortedFileNameHashAndKeyTuples.mapPartitionsWithIndex(
               new HoodieBloomMetaIndexGroupedFunction(hoodieTable, config), true)
           .flatMap(List::iterator).filter(lr -> lr.getMatchingRecordKeys().size() > 0)
           .flatMapToPair(lookupResult -> lookupResult.getMatchingRecordKeys().stream()
               .map(recordKey -> new Tuple2<>(new HoodieKey(recordKey, lookupResult.getPartitionPath()),
                   new HoodieRecordLocation(lookupResult.getBaseInstantTime(), lookupResult.getFileId())))
               .collect(Collectors.toList()).iterator()));
-
-
     }
 
     return HoodieJavaPairRDD.of(fileComparisonsRDD.mapPartitionsWithIndex(new HoodieBloomIndexCheckFunction(hoodieTable, config), true)

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -498,8 +498,6 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
         .withIndexConfig(HoodieIndexConfig.newBuilder()
-            .bloomIndexPruneByRanges(false)
-            .bloomIndexTreebasedFilter(false)
             .bloomIndexBucketizedChecking(false).build())
         .build();
 

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -491,15 +491,48 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     }
   }
 
-  @Test
-  public void testTableOperationsForMetaIndex() throws Exception {
-    HoodieTableType tableType = COPY_ON_WRITE;
+  @ParameterizedTest
+  @EnumSource(HoodieTableType.class)
+  public void testTableOperationsWithMetaIndexLazyLoad(HoodieTableType tableType) throws Exception {
     init(tableType);
-    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
     HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
         .withIndexConfig(HoodieIndexConfig.newBuilder()
-            .bloomIndexBucketizedChecking(false).build())
+            .bloomIndexBucketizedChecking(false)
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .bloomFilterIndex(true)
+            .bloomFilterIndexBatchLoad(false)
+            .columnStatsIndex(true)
+            .indexLookupLogging(false)
+            .indexLookupTimer(true)
+            .build())
         .build();
+    testTableOperationsForMetaIndexImpl(writeConfig);
+  }
+
+  @ParameterizedTest
+  @EnumSource(HoodieTableType.class)
+  public void testTableOperationsWithMetaIndexBatchLoad(HoodieTableType tableType) throws Exception {
+    init(tableType);
+    HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .bloomIndexBucketizedChecking(false)
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .bloomFilterIndex(true)
+            .bloomFilterIndexBatchLoad(true)
+            .columnStatsIndex(true)
+            .indexLookupLogging(false)
+            .indexLookupTimer(true)
+            .build())
+        .build();
+    testTableOperationsForMetaIndexImpl(writeConfig);
+  }
+
+  private void testTableOperationsForMetaIndexImpl(final HoodieWriteConfig writeConfig) throws Exception {
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
 
     try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
       LOG.error("XXX 1 Bulk insert!");

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -139,9 +139,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "are deserialized from it. Enabling this will read each log block as an inline file and read records from the same. For instance, "
           + "for HFileDataBlock, a inline file will be read using HFileReader.");
 
+  // TODO: for the test
   public static final ConfigProperty<Boolean> ENABLE_FULL_SCAN_LOG_FILES = ConfigProperty
       .key(METADATA_PREFIX + ".enable.full.scan.log.files")
-      .defaultValue(true)
+      .defaultValue(false)
       .sinceVersion("0.10.0")
       .withDocumentation("Enable full scanning of log files while reading log records. If disabled, hudi does look up of only interested entries.");
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -61,6 +61,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.10.0")
       .withDocumentation("Enable indexing base files column stats for quicker key lookups");
 
+  public static final ConfigProperty<Boolean> INDEX_LOOKUP_LOGGING = ConfigProperty
+      .key(METADATA_PREFIX + ".index.lookup.logging")
+      .defaultValue(false)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Enable indexing lookup verbose logging");
+
+  public static final ConfigProperty<Boolean> INDEX_LOOKUP_TIMER = ConfigProperty
+      .key(METADATA_PREFIX + ".index.lookup.timer")
+      .defaultValue(true)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Enable indexing lookups timer logging");
+
   public static final boolean DEFAULT_METADATA_ENABLE_FOR_READERS = false;
 
   // Enable metrics for internal Metadata Table
@@ -135,16 +147,26 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .key(METADATA_PREFIX + ".enable.inline.reading")
       .defaultValue(true)
       .sinceVersion("0.10.0")
-      .withDocumentation("Enable inline reading of Log files. By default log block contents are read as byte[] using regular input stream and records "
-          + "are deserialized from it. Enabling this will read each log block as an inline file and read records from the same. For instance, "
+      .withDocumentation("Enable inline reading of Log files. By default log block contents are read as byte[] using "
+          + "regular input stream and records "
+          + "are deserialized from it. Enabling this will read each log block as an inline file and read records from"
+          + " the same. For instance, "
           + "for HFileDataBlock, a inline file will be read using HFileReader.");
 
   // TODO: for the test
   public static final ConfigProperty<Boolean> ENABLE_FULL_SCAN_LOG_FILES = ConfigProperty
       .key(METADATA_PREFIX + ".enable.full.scan.log.files")
+      .defaultValue(true)
+      .sinceVersion("0.10.0")
+      .withDocumentation("Enable full scanning of log files while reading log records. If disabled, hudi does look up"
+          + " of only interested entries.");
+
+  public static final ConfigProperty<Boolean> BLOOM_FILTER_METADATA_BATCH_LOAD_ENABLE = ConfigProperty
+      .key(METADATA_PREFIX + ".bloom_filter.batch_load.enable")
       .defaultValue(false)
       .sinceVersion("0.10.0")
-      .withDocumentation("Enable full scanning of log files while reading log records. If disabled, hudi does look up of only interested entries.");
+      .withDocumentation("Enable batch/bulk loading of bloom filter metadata for the entire partition when looking"
+          + " up index.");
 
   private HoodieMetadataConfig() {
     super();
@@ -168,6 +190,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean isBloomFiltersEnabled() {
     return getBoolean(BLOOM_FILTER_METADATA_ENABLE);
+  }
+
+  public boolean isBloomFiltersBatchLoadEnabled() {
+    return getBoolean(BLOOM_FILTER_METADATA_BATCH_LOAD_ENABLE);
+  }
+
+  public boolean isIndexLookupLoggingEnabled() {
+    return getBoolean(INDEX_LOOKUP_LOGGING);
+  }
+
+  public boolean isIndexLookupTimerEnabled() {
+    return getBoolean(INDEX_LOOKUP_TIMER);
   }
 
   public boolean isColumnStatsEnabled() {
@@ -204,6 +238,31 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder enable(boolean enable) {
       metadataConfig.setValue(ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder bloomFilterIndex(boolean enable) {
+      metadataConfig.setValue(BLOOM_FILTER_METADATA_ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder bloomFilterIndexBatchLoad(boolean enable) {
+      metadataConfig.setValue(BLOOM_FILTER_METADATA_BATCH_LOAD_ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder columnStatsIndex(boolean enable) {
+      metadataConfig.setValue(COLUMN_STATS_METADATA_ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder indexLookupLogging(boolean enable) {
+      metadataConfig.setValue(INDEX_LOOKUP_LOGGING, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder indexLookupTimer(boolean enable) {
+      metadataConfig.setValue(INDEX_LOOKUP_TIMER, String.valueOf(enable));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/ColumnID.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/ColumnID.java
@@ -27,7 +27,7 @@ import org.apache.hudi.common.util.Base64CodecUtil;
 public class ColumnID extends HoodieID {
 
   private static final Type TYPE = Type.COLUMN;
-  private static final HashID.Size ID_COLUMN_HASH_SIZE = HashID.Size.BITS_64;
+  public static final HashID.Size ID_COLUMN_HASH_SIZE = HashID.Size.BITS_64;
   private final byte[] hash;
 
   public ColumnID(final String message) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/BaseTableMetadata.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.avro.model.HoodieMetadataBloomFilter;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.SerializableConfiguration;
@@ -31,6 +32,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.hash.FileID;
 import org.apache.hudi.exception.HoodieMetadataException;
@@ -68,6 +70,7 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
 
   protected boolean enabled;
   protected boolean isBloomFilterMetadataEnabled;
+  protected boolean isColumnStatsMetadataEnabled;
 
   protected BaseTableMetadata(HoodieEngineContext engineContext, HoodieMetadataConfig metadataConfig,
                               String dataBasePath, String spillableMapDirectory) {
@@ -80,6 +83,7 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
 
     this.enabled = metadataConfig.enabled();
     this.isBloomFilterMetadataEnabled = (this.enabled && metadataConfig.isBloomFiltersEnabled());
+    this.isColumnStatsMetadataEnabled = (this.enabled && metadataConfig.isColumnStatsEnabled());
     if (metadataConfig.enableMetrics()) {
       this.metrics = Option.of(new HoodieMetadataMetrics(Registry.getRegistry("HoodieMetadata")));
     } else {
@@ -89,12 +93,11 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
 
   /**
    * Return the list of partitions in the dataset.
-   *
+   * <p>
    * If the Metadata Table is enabled, the listing is retrieved from the stored metadata. Otherwise, the list of
    * partitions is retrieved directly from the underlying {@code FileSystem}.
-   *
+   * <p>
    * On any errors retrieving the listing from the metadata, defaults to using the file system listings.
-   *
    */
   @Override
   public List<String> getAllPartitionPaths() throws IOException {
@@ -111,10 +114,10 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
 
   /**
    * Return the list of files in a partition.
-   *
+   * <p>
    * If the Metadata Table is enabled, the listing is retrieved from the stored metadata. Otherwise, the list of
    * partitions is retrieved directly from the underlying {@code FileSystem}.
-   *
+   * <p>
    * On any errors retrieving the listing from the metadata, defaults to using the file system listings.
    *
    * @param partitionPath The absolute path of the partition to list
@@ -126,11 +129,13 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
       try {
         return fetchAllFilesInPartition(partitionPath);
       } catch (Exception e) {
-        throw new HoodieMetadataException("Failed to retrieve files in partition " + partitionPath + " from metadata", e);
+        throw new HoodieMetadataException("Failed to retrieve files in partition " + partitionPath
+            + " from metadata", e);
       }
     }
 
-    return new FileSystemBackedTableMetadata(getEngineContext(), hadoopConf, dataBasePath, metadataConfig.shouldAssumeDatePartitioning())
+    return new FileSystemBackedTableMetadata(getEngineContext(), hadoopConf, dataBasePath,
+        metadataConfig.shouldAssumeDatePartitioning())
         .getAllFilesInPartition(partitionPath);
   }
 
@@ -147,7 +152,8 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
       }
     }
 
-    return new FileSystemBackedTableMetadata(getEngineContext(), hadoopConf, dataBasePath, metadataConfig.shouldAssumeDatePartitioning())
+    return new FileSystemBackedTableMetadata(getEngineContext(), hadoopConf, dataBasePath,
+        metadataConfig.shouldAssumeDatePartitioning())
         .getAllFilesInPartitions(partitions);
   }
 
@@ -203,6 +209,32 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
     return fileIDBloomFilterMap;
   }
 
+  @Override
+  public Map<String, HoodieColumnStats> getColumnStats(List<String> keySet) throws HoodieMetadataException {
+
+    if (!isColumnStatsMetadataEnabled) {
+      throw new HoodieMetadataException("Metadata table or column stats indexing is disabled!");
+    }
+
+    HoodieTimer timer = new HoodieTimer().startTimer();
+    List<Pair<String, Option<HoodieRecord<HoodieMetadataPayload>>>> hoodieRecordList =
+        getRecordsByKeys(keySet, MetadataPartitionType.COLUMN_STATS.partitionPath());
+    metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.LOOKUP_COLUMN_STATS_METADATA_STR, timer.endTimer()));
+
+    Map<String, HoodieColumnStats> columnKeyToStatMap = new HashMap<>();
+    for (final Pair<String, Option<HoodieRecord<HoodieMetadataPayload>>> entry : hoodieRecordList) {
+      if (entry.getRight().isPresent()) {
+        final Option<HoodieColumnStats> optionalColumnStatPayload =
+            entry.getRight().get().getData().getColumnStatMetadata();
+        if (optionalColumnStatPayload.isPresent()) {
+          ValidationUtils.checkState(!columnKeyToStatMap.containsKey(entry.getLeft()));
+          columnKeyToStatMap.put(entry.getLeft(), optionalColumnStatPayload.get());
+        }
+      }
+    }
+    return columnKeyToStatMap;
+  }
+
   /**
    * Returns a list of all partitions.
    */
@@ -243,7 +275,8 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
     }
 
     HoodieTimer timer = new HoodieTimer().startTimer();
-    Option<HoodieRecord<HoodieMetadataPayload>> hoodieRecord = getRecordByKey(partitionName, MetadataPartitionType.FILES.partitionPath());
+    Option<HoodieRecord<HoodieMetadataPayload>> hoodieRecord = getRecordByKey(partitionName,
+        MetadataPartitionType.FILES.partitionPath());
     metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.LOOKUP_FILES_STR, timer.endTimer()));
 
     FileStatus[] statuses = {};
@@ -262,17 +295,19 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
   Map<String, FileStatus[]> fetchAllFilesInPartitionPaths(List<Path> partitionPaths) throws IOException {
     Map<String, Path> partitionInfo = new HashMap<>();
     boolean foundNonPartitionedPath = false;
-    for (Path partitionPath: partitionPaths) {
+    for (Path partitionPath : partitionPaths) {
       String partitionName = FSUtils.getRelativePartitionPath(new Path(dataBasePath), partitionPath);
       if (partitionName.isEmpty()) {
         if (partitionInfo.size() > 1) {
-          throw new HoodieMetadataException("Found mix of partitioned and non partitioned paths while fetching data from metadata table");
+          throw new HoodieMetadataException("Found mix of partitioned and non partitioned paths while fetching data "
+              + "from metadata table");
         }
         partitionInfo.put(NON_PARTITIONED_NAME, partitionPath);
         foundNonPartitionedPath = true;
       } else {
         if (foundNonPartitionedPath) {
-          throw new HoodieMetadataException("Found mix of partitioned and non partitioned paths while fetching data from metadata table");
+          throw new HoodieMetadataException("Found mix of partitioned and non partitioned paths while fetching data "
+              + "from metadata table");
         }
         partitionInfo.put(partitionName, partitionPath);
       }
@@ -284,13 +319,14 @@ public abstract class BaseTableMetadata implements HoodieTableMetadata {
     metrics.ifPresent(m -> m.updateMetrics(HoodieMetadataMetrics.LOOKUP_FILES_STR, timer.endTimer()));
     Map<String, FileStatus[]> result = new HashMap<>();
 
-    for (Pair<String, Option<HoodieRecord<HoodieMetadataPayload>>> entry: partitionsFileStatus) {
+    for (Pair<String, Option<HoodieRecord<HoodieMetadataPayload>>> entry : partitionsFileStatus) {
       if (entry.getValue().isPresent()) {
         if (!entry.getValue().get().getData().getDeletions().isEmpty()) {
           throw new HoodieMetadataException("Metadata record for partition " + entry.getKey() + " is inconsistent: "
               + entry.getValue().get().getData());
         }
-        result.put(partitionInfo.get(entry.getKey()).toString(), entry.getValue().get().getData().getFileStatuses(hadoopConf.get(), partitionInfo.get(entry.getKey())));
+        result.put(partitionInfo.get(entry.getKey()).toString(),
+            entry.getValue().get().getData().getFileStatuses(hadoopConf.get(), partitionInfo.get(entry.getKey())));
       }
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
@@ -145,11 +146,16 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
 
   @Override
   public Option<ByteBuffer> getBloomFilter(FileID fileID) throws HoodieMetadataException {
-    return Option.empty();
+    throw new HoodieMetadataException("Unsupported operation - getBloomFilter for " + fileID);
   }
 
   @Override
   public Map<String, ByteBuffer> getBloomFilters(List<FileID> fileIDList) throws HoodieMetadataException {
-    return Collections.emptyMap();
+    throw new HoodieMetadataException("Unsupported operation - getBloomFilters!");
+  }
+
+  @Override
+  public Map<String, HoodieColumnStats> getColumnStats(List<String> keySet) throws HoodieMetadataException {
+    throw new HoodieMetadataException("Unsupported operation - getColumnsStats!");
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
@@ -145,12 +146,12 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
   }
 
   @Override
-  public Option<ByteBuffer> getBloomFilter(FileID fileID) throws HoodieMetadataException {
+  public Option<ByteBuffer> getBloomFilter(final PartitionID partitionID, final FileID fileID) throws HoodieMetadataException {
     throw new HoodieMetadataException("Unsupported operation - getBloomFilter for " + fileID);
   }
 
   @Override
-  public Map<String, ByteBuffer> getBloomFilters(List<FileID> fileIDList) throws HoodieMetadataException {
+  public Map<String, ByteBuffer> getBloomFilters(final List<Pair<PartitionID, FileID>> partitionIDFileIDList) throws HoodieMetadataException {
     throw new HoodieMetadataException("Unsupported operation - getBloomFilters!");
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -42,6 +42,7 @@ public class HoodieMetadataMetrics implements Serializable {
   public static final String LOOKUP_PARTITIONS_STR = "lookup_partitions";
   public static final String LOOKUP_FILES_STR = "lookup_files";
   public static final String LOOKUP_BLOOM_FILTERS_METADATA_STR = "lookup_bloom_filters_metadata";
+  public static final String LOOKUP_COLUMN_STATS_METADATA_STR = "lookup_column_stats_metadata";
   public static final String SCAN_STR = "scan";
   public static final String BASEFILE_READ_STR = "basefile_read";
   public static final String INITIALIZE_STR = "initialize";

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -31,6 +31,7 @@ import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.hash.ColumnID;
 import org.apache.hudi.common.util.hash.FileID;
 
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -215,11 +216,13 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    * @param isValid     - Is the valid and the bloom filter valid
    * @return Metadata payload containing the fileID and its bloom filter record
    */
-  public static HoodieRecord<HoodieMetadataPayload> createBloomFilterMetadataRecord(final FileID fileID,
+  public static HoodieRecord<HoodieMetadataPayload> createBloomFilterMetadataRecord(final PartitionID partitionID,
+                                                                                    final FileID fileID,
                                                                                     final String timestamp,
                                                                                     final ByteBuffer bloomFilter,
                                                                                     final boolean isValid) {
-    HoodieKey key = new HoodieKey(fileID.asBase64EncodedString(), MetadataPartitionType.BLOOM_FILTERS.partitionPath());
+    final String bloomFilterKey = partitionID.asBase64EncodedString().concat(fileID.asBase64EncodedString());
+    HoodieKey key = new HoodieKey(bloomFilterKey, MetadataPartitionType.BLOOM_FILTERS.partitionPath());
 
     HoodieMetadataBloomFilter metadataBloomFilter =
         new HoodieMetadataBloomFilter(HoodieMetadataBloomFilterUtil.VERSION_METADATA_BLOOM_FILTER,
@@ -384,11 +387,10 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   // get record key from column stats metadata
   public static String getColumnStatsRecordKey(HoodieColumnStatsMetadata<Comparable> columnStatsMetadata) {
     final ColumnID columnID = new ColumnID(columnStatsMetadata.getColumnName());
-    // TODO: Have partition ID enabled for the real benchmark test
-    // final PartitionID partitionID = new PartitionID(columnStatsMetadata.getPartitionPath());
+    final PartitionID partitionID = new PartitionID(columnStatsMetadata.getPartitionPath());
     final FileID fileID = new FileID(columnStatsMetadata.getFilePath());
     return columnID.asBase64EncodedString()
-        //.concat(partitionID.asBase64EncodedString())
+        .concat(partitionID.asBase64EncodedString())
         .concat(fileID.asBase64EncodedString());
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.hash.ColumnID;
 import org.apache.hudi.common.util.hash.FileID;
 
 import org.apache.hudi.exception.HoodieMetadataException;
@@ -38,6 +39,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.io.api.Binary;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -92,7 +94,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   private int type = 0;
   private Map<String, HoodieMetadataFileInfo> filesystemMetadata = null;
   private HoodieMetadataBloomFilter bloomFilterMetadata = null;
-  private HoodieColumnStats columnStats = null;
+  private HoodieColumnStats columnStatMetadata = null;
 
   public HoodieMetadataPayload(GenericRecord record, Comparable<?> orderingVal) {
     this(Option.of(record));
@@ -137,7 +139,9 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
         if (v == null) {
           throw new HoodieMetadataException("Valid " + METADATA_RECORD_COLUMN_STATS + " record expected for type: " + METADATA_TYPE_COLUMN_STATS);
         }
-        columnStats = new HoodieColumnStats(String.valueOf(v.get("rangeLow")), String.valueOf(v.get("rangeHigh")),
+        columnStatMetadata = new HoodieColumnStats(
+            (String) v.get("rangeLow"),
+            (String) v.get("rangeHigh"),
             (Boolean) v.get("isDeleted"));
       }
     }
@@ -163,7 +167,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     this.type = type;
     this.filesystemMetadata = filesystemMetadata;
     this.bloomFilterMetadata = metadataBloomFilter;
-    this.columnStats = columnStats;
+    this.columnStatMetadata = columnStats;
   }
 
   /**
@@ -250,7 +254,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   }
 
   private HoodieColumnStats combineColumnStats(HoodieMetadataPayload previousRecord) {
-    return this.columnStats;
+    return this.columnStatMetadata;
   }
 
   @Override
@@ -267,7 +271,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     }
 
     HoodieMetadataRecord record = new HoodieMetadataRecord(key, type, filesystemMetadata, bloomFilterMetadata,
-        columnStats);
+        columnStatMetadata);
     return Option.of(record);
   }
 
@@ -294,6 +298,17 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     }
 
     return Option.of(bloomFilterMetadata);
+  }
+
+  /**
+   * Get the bloom filter metadata from this payload.
+   */
+  public Option<HoodieColumnStats> getColumnStatMetadata() {
+    if (columnStatMetadata == null) {
+      return Option.empty();
+    }
+
+    return Option.of(columnStatMetadata);
   }
 
   /**
@@ -355,10 +370,10 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
               //TODO: we are storing range for all columns as string. add support for other primitive types
               // also if min/max is null, we store null for these columns. Should we consider storing String "null"
               // instead?
-              .setRangeHigh(columnStatsMetadata.getMinValue() == null ? "0" :
-                  columnStatsMetadata.getMaxValue().toString())
-              .setRangeLow(columnStatsMetadata.getMinValue() == null ? "0" :
-                  columnStatsMetadata.getMaxValue().toString())
+              .setRangeHigh(columnStatsMetadata.getMaxValue() == null ? null :
+                  new String(((Binary) columnStatsMetadata.getMaxValue()).getBytes()))
+              .setRangeLow(columnStatsMetadata.getMinValue() == null ? null :
+                  new String(((Binary) columnStatsMetadata.getMinValue()).getBytes()))
               .setIsDeleted(false)
               .build());
 
@@ -368,17 +383,20 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
 
   // get record key from column stats metadata
   public static String getColumnStatsRecordKey(HoodieColumnStatsMetadata<Comparable> columnStatsMetadata) {
-    return "column||" + columnStatsMetadata.getColumnName() + ";;partitionPath||"
-        + columnStatsMetadata.getPartitionPath() + ";;fileName||" + columnStatsMetadata.getFilePath();
+    final ColumnID columnID = new ColumnID(columnStatsMetadata.getColumnName());
+    // TODO: Have partition ID enabled for the real benchmark test
+    // final PartitionID partitionID = new PartitionID(columnStatsMetadata.getPartitionPath());
+    final FileID fileID = new FileID(columnStatsMetadata.getFilePath());
+    return columnID.asBase64EncodedString()
+        //.concat(partitionID.asBase64EncodedString())
+        .concat(fileID.asBase64EncodedString());
   }
 
   // parse attribute in record key. TODO: find better way to get this attribute instaed of parsing key
   public static String getAttributeFromRecordKey(String recordKey, String attribute) {
-    String[] attributeNameValuePairs = recordKey.split(";;");
-    return Arrays.stream(attributeNameValuePairs)
-        .filter(nameValue -> nameValue.startsWith(attribute))
-        .findFirst()
-        .map(s -> s.split("\\|\\|")[1]).orElse(null);
+    final String columnIDBase64EncodedString = recordKey.substring(0, ColumnID.ID_COLUMN_HASH_SIZE.bits());
+
+    return "";
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -123,6 +124,16 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * @throws HoodieMetadataException
    */
   Map<String, ByteBuffer> getBloomFilters(final List<FileID> fileIDList) throws HoodieMetadataException;
+
+  /**
+   * TODO: Comment.
+   *
+   * @param keyList
+   * @param keySet
+   * @return
+   * @throws HoodieMetadataException
+   */
+  Map<String, HoodieColumnStats> getColumnStats(final List<String> keySet) throws HoodieMetadataException;
 
   /**
    * Get the instant time to which the metadata is synced w.r.t data timeline.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -26,7 +26,9 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
@@ -114,16 +116,16 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * @return BloomFilter byte buffer if available, otherwise empty
    * @throws HoodieMetadataException
    */
-  Option<ByteBuffer> getBloomFilter(final FileID fileID) throws HoodieMetadataException;
+  Option<ByteBuffer> getBloomFilter(final PartitionID partitionID, final FileID fileID) throws HoodieMetadataException;
 
   /**
    * Get bloom filters for the list of FileIDs from the metadata table.
    *
-   * @param fileIDList - List of FileIDs for which bloom filters need to be retrieved
+   * @param partitionIDFileIDList - List of FileIDs for which bloom filters need to be retrieved
    * @return Map of FileID to its bloom filter byte buffer
    * @throws HoodieMetadataException
    */
-  Map<String, ByteBuffer> getBloomFilters(final List<FileID> fileIDList) throws HoodieMetadataException;
+  Map<String, ByteBuffer> getBloomFilters(final List<Pair<PartitionID, FileID>> partitionIDFileIDList) throws HoodieMetadataException;
 
   /**
    * TODO: Comment.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -46,6 +46,7 @@ import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.common.util.hash.FileID;
+import org.apache.hudi.common.util.hash.PartitionID;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieMetadataException;
 
@@ -245,7 +246,7 @@ public class HoodieTableMetadataUtil {
 
           // TODO: Improve the schema to include the filter type also
           HoodieRecord record = HoodieMetadataPayload.createBloomFilterMetadataRecord(
-              new FileID(filename), instantTime, bloomByteBuffer, true);
+              new PartitionID(partition), new FileID(filename), instantTime, bloomByteBuffer, true);
 
           records.add(record);
           fileReader.close();


### PR DESCRIPTION
## What is the purpose of the pull request

Metadata Index - Column stats metadata to speed up index lookup - read path PoC

## Brief change log

 - Spark findMatchingFilesForRecordKeys now uses the new HoodieBloomMetaIndexColStatFunction
   to prune files using metadata table based column stats

 - After pruning the file list, it uses HoodieBloomMetaIndexGroupedFunction for the metadata
   table based bloom filter lookup to find the actual files for the keys and then does the
   file lookup to confirm the keys presence

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
