### PR TITLE
[HUDI-2714] Benchmark test utils for loading bloom filters from files and index

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1421,6 +1421,11 @@ public class HoodieWriteConfig extends HoodieConfig {
     return isMetadataTableEnabled() && getMetadataConfig().isMetaIndexBloomFilterEnabled();
   }
 
+  public boolean isMetaIndexColumnStatsForAllColumns() {
+    return isMetadataTableEnabled() && isMetaIndexColumnStatsForAllColumns()
+        && getMetadataConfig().isMetaIndexColumnStatsForAllColumns();
+  }
+
   public boolean isMetaIndexBloomFilterBatchLoadEnabled() {
     return isMetadataTableEnabled() && getMetadataConfig().isMetaIndexBloomFilterBatchLoadEnabled();
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1417,6 +1417,14 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieIndexConfig.BLOOM_INDEX_BUCKETIZED_CHECKING);
   }
 
+  public boolean isMetaIndexBloomFilterEnabled() {
+    return isMetadataTableEnabled() && getMetadataConfig().isMetaIndexBloomFilterEnabled();
+  }
+
+  public boolean isMetaIndexBloomFilterBatchLoadEnabled() {
+    return isMetadataTableEnabled() && getMetadataConfig().isMetaIndexBloomFilterBatchLoadEnabled();
+  }
+
   public int getBloomIndexKeysPerBucket() {
     return getInt(HoodieIndexConfig.BLOOM_INDEX_KEYS_PER_BUCKET);
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/bloom/HoodieBloomIndex.java
@@ -19,20 +19,27 @@
 
 package org.apache.hudi.index.bloom;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.function.SerializableFunction;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ImmutablePair;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.ColumnIndexID;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.exception.MetadataNotFoundException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndexUtils;
@@ -43,9 +50,12 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
@@ -80,9 +90,12 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload<T>>
     HoodiePairData<String, String> partitionRecordKeyPairs = records.mapToPair(
         record -> new ImmutablePair<>(record.getPartitionPath(), record.getRecordKey()));
 
+    HoodieTimer timer = new HoodieTimer().startTimer();
     // Step 2: Lookup indexes for all the partition/recordkey pair
     HoodiePairData<HoodieKey, HoodieRecordLocation> keyFilenamePairs =
         lookupIndex(partitionRecordKeyPairs, context, hoodieTable);
+    final long indexLookupTime = timer.endTimer();
+    LOG.debug("Index lookup time taken: " + indexLookupTime + " ms");
 
     // Cache the result, for subsequent stages.
     if (config.getBloomIndexUseCaching()) {
@@ -111,13 +124,14 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload<T>>
   private HoodiePairData<HoodieKey, HoodieRecordLocation> lookupIndex(
       HoodiePairData<String, String> partitionRecordKeyPairs, final HoodieEngineContext context,
       final HoodieTable hoodieTable) {
-    // Obtain records per partition, in the incoming records
+    // Step 1: Obtain records per partition, in the incoming records
     Map<String, Long> recordsPerPartition = partitionRecordKeyPairs.countByKey();
     List<String> affectedPartitionPathList = new ArrayList<>(recordsPerPartition.keySet());
 
     // Step 2: Load all involved files as <Partition, filename> pairs
-    List<Pair<String, BloomIndexFileInfo>> fileInfoList =
-        loadInvolvedFiles(affectedPartitionPathList, context, hoodieTable);
+    List<Pair<String, BloomIndexFileInfo>> fileInfoList = (config.getMetadataConfig().isMetaIndexColumnStatsEnabled()
+        ? loadColumnStats(affectedPartitionPathList, context, hoodieTable) :
+        loadInvolvedFiles(affectedPartitionPathList, context, hoodieTable));
     final Map<String, List<BloomIndexFileInfo>> partitionToFileInfo =
         fileInfoList.stream().collect(groupingBy(Pair::getLeft, mapping(Pair::getRight, toList())));
 
@@ -153,6 +167,70 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload<T>>
           return Pair.of(pf.getKey(), new BloomIndexFileInfo(pf.getValue()));
         }
       }, Math.max(partitionPathFileIDList.size(), 1));
+    } else {
+      return partitionPathFileIDList.stream()
+          .map(pf -> Pair.of(pf.getKey(), new BloomIndexFileInfo(pf.getValue()))).collect(toList());
+    }
+  }
+
+  /**
+   * Load the column stats as BloomIndexFileInfo for all the involved files in the partition.
+   *
+   * @param partitions  - List of partitions for which column stats need to be loaded
+   * @param context     - Engine context
+   * @param hoodieTable - Hoodie table
+   */
+  List<Pair<String, BloomIndexFileInfo>> loadColumnStats(
+      List<String> partitions, final HoodieEngineContext context, final HoodieTable hoodieTable) {
+    // Obtain the latest data files from all the partitions.
+    List<Pair<String, String>> partitionPathFileIDList = getLatestBaseFilesForAllPartitions(partitions, context,
+        hoodieTable).stream()
+        .map(pair -> Pair.of(pair.getKey(), pair.getValue().getFileId()))
+        .collect(toList());
+
+    if (config.getBloomIndexPruneByRanges()) {
+      // also obtain file ranges, if range pruning is enabled
+      context.setJobStatus(this.getClass().getName(), "Obtain key ranges for file slices (range pruning=on)");
+
+      return context.flatMap(partitions, new SerializableFunction<String, Stream<Pair<String, BloomIndexFileInfo>>>() {
+        @Override
+        public Stream<Pair<String, BloomIndexFileInfo>> apply(String partitionName) throws Exception {
+          final String columnIndexID = new ColumnIndexID(HoodieRecord.RECORD_KEY_METADATA_FIELD).asBase64EncodedString();
+          final String partitionIndexID = new PartitionIndexID(partitionName).asBase64EncodedString();
+
+          List<Pair<String, String>> partitionFileIdList =
+              HoodieIndexUtils.getLatestBaseFilesForPartition(partitionName,
+                      hoodieTable).stream().map(baseFile -> Pair.of(baseFile.getFileId(), baseFile.getFileName()))
+                  .collect(toList());
+          try {
+            Map<String, String> columnStatKeyToFileIdMap = new HashMap<>();
+            List<String> columnStatKeys = new ArrayList<>();
+            for (Pair<String, String> fileIdFileName : partitionFileIdList) {
+              final String columnStatIndexKey = columnIndexID
+                  .concat(partitionIndexID)
+                  .concat(new FileIndexID(fileIdFileName.getRight()).asBase64EncodedString());
+              columnStatKeys.add(columnStatIndexKey);
+              columnStatKeyToFileIdMap.put(columnStatIndexKey, fileIdFileName.getLeft());
+            }
+            Collections.sort(columnStatKeys);
+
+            Map<String, HoodieColumnStats> columnKeyHashToStatMap = hoodieTable
+                .getMetadataTable().getColumnStats(columnStatKeys);
+            List<Pair<String, BloomIndexFileInfo>> result = new ArrayList<>();
+            for (Map.Entry<String, HoodieColumnStats> entry : columnKeyHashToStatMap.entrySet()) {
+              result.add(Pair.of(partitionName,
+                  new BloomIndexFileInfo(
+                      columnStatKeyToFileIdMap.get(entry.getKey()),
+                      entry.getValue().getMinValue(),
+                      entry.getValue().getMaxValue()
+                  )));
+            }
+            return result.stream();
+          } catch (MetadataNotFoundException me) {
+            throw new HoodieMetadataException("Unable to find column range metadata for partition:" + partitionName, me);
+          }
+        }
+      }, Math.max(partitions.size(), 1));
     } else {
       return partitionPathFileIDList.stream()
           .map(pf -> Pair.of(pf.getKey(), new BloomIndexFileInfo(pf.getValue()))).collect(toList());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexGroupedLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexGroupedLookupHandle.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Takes a bunch of keys and returns ones that are present in the file group.
+ */
+public class HoodieKeyMetaBloomIndexGroupedLookupHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieReadHandle<T,
+    I, K, O> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieKeyMetaBloomIndexGroupedLookupHandle.class);
+
+  private final HoodieTableType tableType;
+
+  private final BloomFilter bloomFilter;
+
+  private final List<String> candidateRecordKeys;
+
+  private long totalKeysChecked;
+
+  public HoodieKeyMetaBloomIndexGroupedLookupHandle(HoodieWriteConfig config, HoodieTable<T, I, K, O> hoodieTable,
+                                                    Pair<String, String> partitionPathFileIdPair, String fileName) {
+    super(config, null, hoodieTable, partitionPathFileIdPair);
+    this.tableType = hoodieTable.getMetaClient().getTableType();
+
+    this.candidateRecordKeys = new ArrayList<>();
+    this.totalKeysChecked = 0;
+    HoodieTimer timer = new HoodieTimer().startTimer();
+
+    Option<ByteBuffer> bloomFilterByteBuffer =
+        hoodieTable.getMetadataTable().getBloomFilter(new PartitionIndexID(partitionPathFileIdPair.getLeft()),
+            new FileIndexID(fileName));
+    if (!bloomFilterByteBuffer.isPresent()) {
+      throw new HoodieIndexException("BloomFilter missing for " + fileName);
+    }
+
+    // TODO: Go via the factory and the filter type
+    this.bloomFilter =
+        new HoodieDynamicBoundedBloomFilter(StandardCharsets.UTF_8.decode(bloomFilterByteBuffer.get()).toString(),
+            BloomFilterTypeCode.DYNAMIC_V0);
+
+    LOG.debug(String.format("Read bloom filter from %s,%s, size: %s in %d ms", partitionPathFileIdPair, fileName,
+        bloomFilterByteBuffer.get().array().length, timer.endTimer()));
+  }
+
+  /**
+   * Given a list of row keys and one file, return only row keys existing in that file.
+   */
+  public List<String> checkCandidatesAgainstFile(Configuration configuration, List<String> candidateRecordKeys,
+                                                 Path filePath) throws HoodieIndexException {
+    List<String> foundRecordKeys = new ArrayList<>();
+    try {
+      // Load all rowKeys from the file, to double-confirm
+      if (!candidateRecordKeys.isEmpty()) {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+        Set<String> fileRowKeys = createNewFileReader().filterRowKeys(new HashSet<>(candidateRecordKeys));
+        foundRecordKeys.addAll(fileRowKeys);
+        LOG.debug(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)", filePath,
+            timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
+        LOG.debug("Keys matching for file " + filePath + " => " + foundRecordKeys);
+      }
+    } catch (Exception e) {
+      throw new HoodieIndexException("Error checking candidate keys against file.", e);
+    }
+    return foundRecordKeys;
+  }
+
+  /**
+   * Adds the key for look up.
+   */
+  public void addKey(String recordKey) {
+    // check record key against bloom filter of current file & add to possible keys if needed
+    if (bloomFilter.mightContain(recordKey)) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Record key " + recordKey + " matches bloom filter in  " + partitionPathFilePair);
+      }
+      candidateRecordKeys.add(recordKey);
+    }
+    totalKeysChecked++;
+  }
+
+  /**
+   * Of all the keys, that were added, return a list of keys that were actually found in the file group.
+   */
+  public MetaBloomIndexGroupedKeyLookupResult getLookupResult() {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("#The candidate row keys for " + partitionPathFilePair + " => " + candidateRecordKeys);
+    }
+
+    HoodieBaseFile dataFile = getLatestDataFile();
+    List<String> matchingKeys =
+        checkCandidatesAgainstFile(hoodieTable.getHadoopConf(), candidateRecordKeys, new Path(dataFile.getPath()));
+    LOG.debug(
+        String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)", totalKeysChecked,
+            candidateRecordKeys.size(), candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+    return new MetaBloomIndexGroupedKeyLookupResult(partitionPathFilePair.getRight(), partitionPathFilePair.getLeft(),
+        dataFile.getCommitTime(), matchingKeys);
+  }
+
+  /**
+   * Encapsulates the result from a key lookup.
+   */
+  public static class MetaBloomIndexGroupedKeyLookupResult {
+
+    private final String fileId;
+    private final String baseInstantTime;
+    private final List<String> matchingRecordKeys;
+    private final String partitionPath;
+
+    public MetaBloomIndexGroupedKeyLookupResult(String fileId, String partitionPath, String baseInstantTime,
+                                                List<String> matchingRecordKeys) {
+      this.fileId = fileId;
+      this.partitionPath = partitionPath;
+      this.baseInstantTime = baseInstantTime;
+      this.matchingRecordKeys = matchingRecordKeys;
+    }
+
+    public String getFileId() {
+      return fileId;
+    }
+
+    public String getBaseInstantTime() {
+      return baseInstantTime;
+    }
+
+    public String getPartitionPath() {
+      return partitionPath;
+    }
+
+    public List<String> getMatchingRecordKeys() {
+      return matchingRecordKeys;
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaBloomIndexLookupHandle.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Takes a bunch of keys and returns ones that are present in the file group.
+ */
+public class HoodieKeyMetaBloomIndexLookupHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieReadHandle<T,
+    I, K, O> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieKeyMetaBloomIndexLookupHandle.class);
+  private final HoodieTableType tableType;
+  private final BloomFilter bloomFilter;
+  private final List<String> candidateRecordKeys;
+  private long totalKeysChecked;
+
+  public HoodieKeyMetaBloomIndexLookupHandle(HoodieWriteConfig config, HoodieTable<T, I, K, O> hoodieTable,
+                                             Pair<String, String> partitionPathFileIdPair, String fileName) {
+    super(config, null, hoodieTable, partitionPathFileIdPair);
+    this.tableType = hoodieTable.getMetaClient().getTableType();
+    this.candidateRecordKeys = new ArrayList<>();
+    this.totalKeysChecked = 0;
+
+    HoodieTimer timer = new HoodieTimer().startTimer();
+    Option<ByteBuffer> bloomFilterByteBuffer =
+        hoodieTable.getMetadataTable().getBloomFilter(new PartitionIndexID(partitionPathFileIdPair.getLeft()),
+            new FileIndexID(fileName));
+    if (!bloomFilterByteBuffer.isPresent()) {
+      throw new HoodieIndexException("BloomFilter missing for " + fileName);
+    }
+
+    // TODO: Go via the factory and the filter type
+    this.bloomFilter =
+        new HoodieDynamicBoundedBloomFilter(StandardCharsets.UTF_8.decode(bloomFilterByteBuffer.get()).toString(),
+            BloomFilterTypeCode.DYNAMIC_V0);
+    LOG.debug(String.format("Read bloom filter from %s,%s, size: %s in %d ms", partitionPathFileIdPair, fileName,
+        bloomFilterByteBuffer.get().array().length, timer.endTimer()));
+  }
+
+  /**
+   * Given a list of row keys and one file, return only row keys existing in that file.
+   */
+  public List<String> checkCandidatesAgainstFile(Configuration configuration, List<String> candidateRecordKeys,
+                                                 Path filePath) throws HoodieIndexException {
+    List<String> foundRecordKeys = new ArrayList<>();
+    try {
+      // Load all rowKeys from the file, to double-confirm
+      if (!candidateRecordKeys.isEmpty()) {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+        Set<String> fileRowKeys = createNewFileReader().filterRowKeys(new HashSet<>(candidateRecordKeys));
+        foundRecordKeys.addAll(fileRowKeys);
+        LOG.debug(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)", filePath,
+            timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
+        LOG.debug("Keys matching for file " + filePath + " => " + foundRecordKeys);
+      }
+    } catch (Exception e) {
+      throw new HoodieIndexException("Error checking candidate keys against file.", e);
+    }
+    return foundRecordKeys;
+  }
+
+  /**
+   * Adds the key for look up.
+   */
+  public void addKey(String recordKey) {
+    // check record key against bloom filter of current file & add to possible keys if needed
+    if (bloomFilter.mightContain(recordKey)) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Record key " + recordKey + " matches bloom filter in  " + partitionPathFilePair);
+      }
+      candidateRecordKeys.add(recordKey);
+    }
+    totalKeysChecked++;
+  }
+
+  /**
+   * Of all the keys, that were added, return a list of keys that were actually found in the file group.
+   */
+  public MetaBloomIndexKeyLookupResult getLookupResult() {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("#The candidate row keys for " + partitionPathFilePair + " => " + candidateRecordKeys);
+    }
+
+    HoodieBaseFile dataFile = getLatestDataFile();
+    List<String> matchingKeys =
+        checkCandidatesAgainstFile(hoodieTable.getHadoopConf(), candidateRecordKeys, new Path(dataFile.getPath()));
+    LOG.debug(String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)",
+        totalKeysChecked, candidateRecordKeys.size(), candidateRecordKeys.size() - matchingKeys.size(),
+        matchingKeys.size()));
+    return new MetaBloomIndexKeyLookupResult(partitionPathFilePair.getRight(), partitionPathFilePair.getLeft(),
+        dataFile.getCommitTime(), matchingKeys);
+  }
+
+  /**
+   * Encapsulates the result from a key lookup.
+   */
+  public static class MetaBloomIndexKeyLookupResult {
+
+    private final String fileId;
+    private final String baseInstantTime;
+    private final List<String> matchingRecordKeys;
+    private final String partitionPath;
+
+    public MetaBloomIndexKeyLookupResult(String fileId, String partitionPath, String baseInstantTime,
+                                         List<String> matchingRecordKeys) {
+      this.fileId = fileId;
+      this.partitionPath = partitionPath;
+      this.baseInstantTime = baseInstantTime;
+      this.matchingRecordKeys = matchingRecordKeys;
+    }
+
+    public String getFileId() {
+      return fileId;
+    }
+
+    public String getBaseInstantTime() {
+      return baseInstantTime;
+    }
+
+    public String getPartitionPath() {
+      return partitionPath;
+    }
+
+    public List<String> getMatchingRecordKeys() {
+      return matchingRecordKeys;
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaIndexBatchLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaIndexBatchLookupHandle.java
@@ -47,10 +47,10 @@ import java.util.Set;
 /**
  * Takes a bunch of keys and returns ones that are present in the file group.
  */
-public class HoodieKeyMetaBloomIndexGroupedLookupHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieReadHandle<T,
+public class HoodieKeyMetaIndexBatchLookupHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieReadHandle<T,
     I, K, O> {
 
-  private static final Logger LOG = LogManager.getLogger(HoodieKeyMetaBloomIndexGroupedLookupHandle.class);
+  private static final Logger LOG = LogManager.getLogger(HoodieKeyMetaIndexBatchLookupHandle.class);
 
   private final HoodieTableType tableType;
 
@@ -60,8 +60,8 @@ public class HoodieKeyMetaBloomIndexGroupedLookupHandle<T extends HoodieRecordPa
 
   private long totalKeysChecked;
 
-  public HoodieKeyMetaBloomIndexGroupedLookupHandle(HoodieWriteConfig config, HoodieTable<T, I, K, O> hoodieTable,
-                                                    Pair<String, String> partitionPathFileIdPair, String fileName) {
+  public HoodieKeyMetaIndexBatchLookupHandle(HoodieWriteConfig config, HoodieTable<T, I, K, O> hoodieTable,
+                                             Pair<String, String> partitionPathFileIdPair, String fileName) {
     super(config, null, hoodieTable, partitionPathFileIdPair);
     this.tableType = hoodieTable.getMetaClient().getTableType();
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaIndexLookupHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieKeyMetaIndexLookupHandle.java
@@ -47,17 +47,17 @@ import java.util.Set;
 /**
  * Takes a bunch of keys and returns ones that are present in the file group.
  */
-public class HoodieKeyMetaBloomIndexLookupHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieReadHandle<T,
+public class HoodieKeyMetaIndexLookupHandle<T extends HoodieRecordPayload, I, K, O> extends HoodieReadHandle<T,
     I, K, O> {
 
-  private static final Logger LOG = LogManager.getLogger(HoodieKeyMetaBloomIndexLookupHandle.class);
+  private static final Logger LOG = LogManager.getLogger(HoodieKeyMetaIndexLookupHandle.class);
   private final HoodieTableType tableType;
   private final BloomFilter bloomFilter;
   private final List<String> candidateRecordKeys;
   private long totalKeysChecked;
 
-  public HoodieKeyMetaBloomIndexLookupHandle(HoodieWriteConfig config, HoodieTable<T, I, K, O> hoodieTable,
-                                             Pair<String, String> partitionPathFileIdPair, String fileName) {
+  public HoodieKeyMetaIndexLookupHandle(HoodieWriteConfig config, HoodieTable<T, I, K, O> hoodieTable,
+                                        Pair<String, String> partitionPathFileIdPair, String fileId) {
     super(config, null, hoodieTable, partitionPathFileIdPair);
     this.tableType = hoodieTable.getMetaClient().getTableType();
     this.candidateRecordKeys = new ArrayList<>();
@@ -66,16 +66,16 @@ public class HoodieKeyMetaBloomIndexLookupHandle<T extends HoodieRecordPayload, 
     HoodieTimer timer = new HoodieTimer().startTimer();
     Option<ByteBuffer> bloomFilterByteBuffer =
         hoodieTable.getMetadataTable().getBloomFilter(new PartitionIndexID(partitionPathFileIdPair.getLeft()),
-            new FileIndexID(fileName));
+            new FileIndexID(fileId));
     if (!bloomFilterByteBuffer.isPresent()) {
-      throw new HoodieIndexException("BloomFilter missing for " + fileName);
+      throw new HoodieIndexException("BloomFilter missing for " + fileId);
     }
 
     // TODO: Go via the factory and the filter type
     this.bloomFilter =
         new HoodieDynamicBoundedBloomFilter(StandardCharsets.UTF_8.decode(bloomFilterByteBuffer.get()).toString(),
             BloomFilterTypeCode.DYNAMIC_V0);
-    LOG.debug(String.format("Read bloom filter from %s,%s, size: %s in %d ms", partitionPathFileIdPair, fileName,
+    LOG.debug(String.format("Read bloom filter from %s,%s, size: %s in %d ms", partitionPathFileIdPair, fileId,
         bloomFilterByteBuffer.get().array().length, timer.endTimer()));
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.io;
 
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.util.collection.Pair;
@@ -27,9 +29,6 @@ import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 import org.apache.hudi.table.HoodieTable;
 
 import java.io.IOException;
-
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 
 /**
  * Base class for read operations done logically on the file group.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -630,7 +630,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
   @Override
   public void update(HoodieCommitMetadata commitMetadata, String instantTime, boolean isTableServiceAction) {
     processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, enabledPartitionTypes,
-        commitMetadata, dataMetaClient, instantTime), !isTableServiceAction);
+        commitMetadata, dataMetaClient, getWriteConfig().isMetaIndexColumnStatsForAllColumns(), instantTime), !isTableServiceAction);
   }
 
   /**
@@ -642,7 +642,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
   @Override
   public void update(HoodieCleanMetadata cleanMetadata, String instantTime) {
     processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, enabledPartitionTypes,
-        cleanMetadata, instantTime), false);
+        cleanMetadata, dataMetaClient, instantTime), false);
   }
 
   /**
@@ -654,7 +654,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
   @Override
   public void update(HoodieRestoreMetadata restoreMetadata, String instantTime) {
     processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext,
-        enabledPartitionTypes, metadataMetaClient.getActiveTimeline(), restoreMetadata, instantTime,
+        enabledPartitionTypes, metadataMetaClient.getActiveTimeline(), restoreMetadata, dataMetaClient, instantTime,
         metadata.getSyncedInstantTime()), false);
   }
 
@@ -681,7 +681,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
 
       Map<MetadataPartitionType, HoodieData<HoodieRecord>> records =
           HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, enabledPartitionTypes,
-              metadataMetaClient.getActiveTimeline(), rollbackMetadata, instantTime,
+              metadataMetaClient.getActiveTimeline(), rollbackMetadata, dataMetaClient, instantTime,
               metadata.getSyncedInstantTime(), wasSynced);
       commit(instantTime, records, false);
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -109,6 +109,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
   protected boolean enabled;
   protected SerializableConfiguration hadoopConf;
   protected final transient HoodieEngineContext engineContext;
+  protected final List<MetadataPartitionType> enabledPartitionTypes;
 
   /**
    * Hudi backed table metadata writer.
@@ -128,8 +129,17 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
     this.dataWriteConfig = writeConfig;
     this.engineContext = engineContext;
     this.hadoopConf = new SerializableConfiguration(hadoopConf);
+    this.metrics = Option.empty();
+    this.enabledPartitionTypes = new ArrayList<>();
 
     if (writeConfig.isMetadataTableEnabled()) {
+      this.enabledPartitionTypes.add(MetadataPartitionType.FILES);
+      if (writeConfig.getMetadataConfig().isMetaIndexBloomFilterEnabled()) {
+        this.enabledPartitionTypes.add(MetadataPartitionType.BLOOM_FILTERS);
+      }
+      if (writeConfig.getMetadataConfig().isMetaIndexColumnStatsEnabled()) {
+        this.enabledPartitionTypes.add(MetadataPartitionType.COLUMN_STATS);
+      }
       this.tableName = writeConfig.getTableName() + METADATA_TABLE_NAME_SUFFIX;
       this.metadataWriteConfig = createMetadataWriteConfig(writeConfig);
       enabled = true;
@@ -152,7 +162,6 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
       initTableMetadata();
     } else {
       enabled = false;
-      this.metrics = Option.empty();
     }
   }
 
@@ -257,8 +266,12 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
     return metadataWriteConfig;
   }
 
-  public HoodieBackedTableMetadata metadata() {
+  public HoodieBackedTableMetadata getTableMetadata() {
     return metadata;
+  }
+
+  public List<MetadataPartitionType> getEnabledPartitionTypes() {
+    return this.enabledPartitionTypes;
   }
 
   /**
@@ -460,7 +473,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
         .initTable(hadoopConf.get(), metadataWriteConfig.getBasePath());
 
     initTableMetadata();
-    initializeFileGroups(dataMetaClient, MetadataPartitionType.FILES, createInstantTime, 1);
+    initializeEnabledFileGroups(dataMetaClient, createInstantTime);
 
     // List all partitions in the basePath of the containing dataset
     LOG.info("Initializing metadata table by using file listings in " + dataWriteConfig.getBasePath());
@@ -530,6 +543,20 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
   }
 
   /**
+   * Initialize file groups for all the enabled partition types.
+   *
+   * @param dataMetaClient    - Meta client for the data table
+   * @param createInstantTime - Metadata table create instant time
+   * @throws IOException
+   */
+  private void initializeEnabledFileGroups(HoodieTableMetaClient dataMetaClient, String createInstantTime) throws IOException {
+    for (MetadataPartitionType enabledPartitionType : this.enabledPartitionTypes) {
+      initializeFileGroups(dataMetaClient, enabledPartitionType, createInstantTime,
+          enabledPartitionType.getFileGroupCount());
+    }
+  }
+
+  /**
    * Initialize file groups for a partition. For file listing, we just have one file group.
    *
    * All FileGroups for a given metadata partition has a fixed prefix as per the {@link MetadataPartitionType#getFileIdPrefix()}.
@@ -577,7 +604,7 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    * Updates of different commit metadata uses the same method to convert to HoodieRecords and hence.
    */
   private interface ConvertMetadataFunction {
-    List<HoodieRecord> convertMetadata();
+    Map<MetadataPartitionType, HoodieData<HoodieRecord>> convertMetadata();
   }
 
   /**
@@ -589,8 +616,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    */
   private <T> void processAndCommit(String instantTime, ConvertMetadataFunction convertMetadataFunction, boolean canTriggerTableService) {
     if (enabled && metadata != null) {
-      List<HoodieRecord> records = convertMetadataFunction.convertMetadata();
-      commit(engineContext.parallelize(records, 1), MetadataPartitionType.FILES.partitionPath(), instantTime, canTriggerTableService);
+      Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionRecordsMap = convertMetadataFunction.convertMetadata();
+      commit(instantTime, partitionRecordsMap, canTriggerTableService);
     }
   }
 
@@ -602,7 +629,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    */
   @Override
   public void update(HoodieCommitMetadata commitMetadata, String instantTime, boolean isTableServiceAction) {
-    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(commitMetadata, instantTime), !isTableServiceAction);
+    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, enabledPartitionTypes,
+        commitMetadata, dataMetaClient, instantTime), !isTableServiceAction);
   }
 
   /**
@@ -613,8 +641,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    */
   @Override
   public void update(HoodieCleanMetadata cleanMetadata, String instantTime) {
-    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(cleanMetadata, instantTime),
-        false);
+    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, enabledPartitionTypes,
+        cleanMetadata, instantTime), false);
   }
 
   /**
@@ -625,8 +653,9 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
    */
   @Override
   public void update(HoodieRestoreMetadata restoreMetadata, String instantTime) {
-    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(metadataMetaClient.getActiveTimeline(),
-        restoreMetadata, instantTime, metadata.getSyncedInstantTime()), false);
+    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext,
+        enabledPartitionTypes, metadataMetaClient.getActiveTimeline(), restoreMetadata, instantTime,
+        metadata.getSyncedInstantTime()), false);
   }
 
   /**
@@ -650,9 +679,11 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
         }
       }
 
-      List<HoodieRecord> records = HoodieTableMetadataUtil.convertMetadataToRecords(metadataMetaClient.getActiveTimeline(), rollbackMetadata, instantTime,
-          metadata.getSyncedInstantTime(), wasSynced);
-      commit(engineContext.parallelize(records, 1), MetadataPartitionType.FILES.partitionPath(), instantTime, false);
+      Map<MetadataPartitionType, HoodieData<HoodieRecord>> records =
+          HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, enabledPartitionTypes,
+              metadataMetaClient.getActiveTimeline(), rollbackMetadata, instantTime,
+              metadata.getSyncedInstantTime(), wasSynced);
+      commit(instantTime, records, false);
     }
   }
 
@@ -665,12 +696,14 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
 
   /**
    * Commit the {@code HoodieRecord}s to Metadata Table as a new delta-commit.
-   *  @param records The HoodieData of records to be written.
-   * @param partitionName The partition to which the records are to be written.
-   * @param instantTime The timestamp to use for the deltacommit.
+   *
+   * @param instantTime            - Action instant time for this commit
+   * @param partitionRecordsMap    - Map of partition name to its records to commit
    * @param canTriggerTableService true if table services can be scheduled and executed. false otherwise.
    */
-  protected abstract void commit(HoodieData<HoodieRecord> records, String partitionName, String instantTime, boolean canTriggerTableService);
+  protected abstract void commit(
+      String instantTime, Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionRecordsMap,
+      boolean canTriggerTableService);
 
   /**
    *  Perform a compaction on the Metadata Table.
@@ -735,14 +768,19 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
     List<String> partitions = partitionInfoList.stream().map(p ->
         p.getRelativePath().isEmpty() ? NON_PARTITIONED_NAME : p.getRelativePath()).collect(Collectors.toList());
     final int totalFiles = partitionInfoList.stream().mapToInt(p -> p.getTotalFiles()).sum();
+    final Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
 
     // Record which saves the list of all partitions
     HoodieRecord allPartitionRecord = HoodieMetadataPayload.createPartitionListRecord(partitions);
     if (partitions.isEmpty()) {
-      // in case of boostrapping of a fresh table, there won't be any partitions, but we need to make a boostrap commit
-      commit(engineContext.parallelize(Collections.singletonList(allPartitionRecord), 1), MetadataPartitionType.FILES.partitionPath(), createInstantTime, false);
+      // in case of bootstrapping of a fresh table, there won't be any partitions, but we need to make a boostrap commit
+      final HoodieData<HoodieRecord> allPartitionRecordsRDD = engineContext.parallelize(
+          Collections.singletonList(allPartitionRecord), 1);
+      partitionToRecordsMap.put(MetadataPartitionType.FILES, allPartitionRecordsRDD);
+      commit(createInstantTime, partitionToRecordsMap, false);
       return;
     }
+
     HoodieData<HoodieRecord> partitionRecords = engineContext.parallelize(Arrays.asList(allPartitionRecord), 1);
     if (!partitionInfoList.isEmpty()) {
       HoodieData<HoodieRecord> fileListRecords = engineContext.parallelize(partitionInfoList, partitionInfoList.size()).map(partitionInfo -> {
@@ -755,7 +793,8 @@ public abstract class HoodieBackedTableMetadataWriter implements HoodieTableMeta
 
     LOG.info("Committing " + partitions.size() + " partitions and " + totalFiles + " files to metadata");
     ValidationUtils.checkState(partitionRecords.count() == (partitions.size() + 1));
-    commit(partitionRecords, MetadataPartitionType.FILES.partitionPath(), createInstantTime, false);
+    partitionToRecordsMap.put(MetadataPartitionType.FILES, partitionRecords);
+    commit(createInstantTime, partitionToRecordsMap, false);
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -783,4 +783,7 @@ public abstract class HoodieTable<T extends HoodieRecordPayload, I, K, O> implem
     return Option.empty();
   }
 
+  public HoodieTableMetadata getMetadataTable() {
+    return this.metadata;
+  }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexBatchCheckFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexBatchCheckFunction.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.bloom.HoodieDynamicBoundedBloomFilter;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.io.HoodieKeyMetaBloomIndexGroupedLookupHandle.MetaBloomIndexGroupedKeyLookupResult;
+import org.apache.hudi.io.storage.HoodieFileReader;
+import org.apache.hudi.io.storage.HoodieFileReaderFactory;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.function.Function2;
+import scala.Tuple2;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Function performing actual checking of RDD partition containing (fileId, hoodieKeys) against the actual files.
+ */
+public class HoodieBloomMetaIndexBatchCheckFunction
+    implements Function2<Integer, Iterator<Tuple2<Tuple2<String, String>, HoodieKey>>,
+    Iterator<List<MetaBloomIndexGroupedKeyLookupResult>>> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieBloomMetaIndexBatchCheckFunction.class);
+  private final HoodieTable hoodieTable;
+  private final HoodieWriteConfig config;
+
+  public HoodieBloomMetaIndexBatchCheckFunction(HoodieTable hoodieTable, HoodieWriteConfig config) {
+    this.hoodieTable = hoodieTable;
+    this.config = config;
+  }
+
+  @Override
+  public Iterator<List<MetaBloomIndexGroupedKeyLookupResult>> call(Integer integer,
+                                                                   Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tupleIterator) throws Exception {
+    List<List<MetaBloomIndexGroupedKeyLookupResult>> resultList = new ArrayList<>();
+
+    // <PartitionPath, FileName> => List<HoodieKey>
+    Map<Pair<String, String>, List<HoodieKey>> fileToKeysMap = new HashMap<>();
+
+    while (tupleIterator.hasNext()) {
+      Tuple2<Tuple2<String, String>, HoodieKey> entry = tupleIterator.next();
+      fileToKeysMap.computeIfAbsent(Pair.of(entry._2.getPartitionPath(), entry._1._1), k -> new ArrayList<>()).add(entry._2);
+    }
+
+    List<Pair<PartitionIndexID, FileIndexID>> partitionIDFileIDList =
+        fileToKeysMap.keySet().stream().map(partitionFileNamePair -> {
+          return Pair.of(new PartitionIndexID(partitionFileNamePair.getLeft()),
+              new FileIndexID(partitionFileNamePair.getRight()));
+        }).collect(Collectors.toList());
+
+    Map<String, ByteBuffer> fileIDToBloomFilterByteBufferMap =
+        hoodieTable.getMetadataTable().getBloomFilters(partitionIDFileIDList);
+
+    fileToKeysMap.forEach((partitionPathFileNamePair, hoodieKeyList) -> {
+      final String partitionPath = partitionPathFileNamePair.getLeft();
+      final String fileName = partitionPathFileNamePair.getRight();
+
+      final String fileId = FSUtils.getFileId(fileName);
+      ValidationUtils.checkState(!fileId.isEmpty());
+
+      final String partitionIDHash = new PartitionIndexID(partitionPath).asBase64EncodedString();
+      final String fileIDHash = new FileIndexID(fileName).asBase64EncodedString();
+      final String bloomKey = partitionIDHash.concat(fileIDHash);
+      if (!fileIDToBloomFilterByteBufferMap.containsKey(bloomKey)) {
+        throw new HoodieIndexException("Failed to get the bloom filter for " + partitionPathFileNamePair);
+      }
+      final ByteBuffer fileBloomFilterByteBuffer = fileIDToBloomFilterByteBufferMap.get(bloomKey);
+
+      HoodieDynamicBoundedBloomFilter fileBloomFilter =
+          new HoodieDynamicBoundedBloomFilter(StandardCharsets.UTF_8.decode(fileBloomFilterByteBuffer).toString(),
+              BloomFilterTypeCode.DYNAMIC_V0);
+
+      List<String> candidateRecordKeys = new ArrayList<>();
+      hoodieKeyList.forEach(hoodieKey -> {
+        if (fileBloomFilter.mightContain(hoodieKey.getRecordKey())) {
+          candidateRecordKeys.add(hoodieKey.getRecordKey());
+        }
+      });
+
+      Option<HoodieBaseFile> dataFile = hoodieTable.getBaseFileOnlyView()
+          .getLatestBaseFile(partitionPath, fileId);
+      if (!dataFile.isPresent()) {
+        throw new HoodieIndexException("Failed to find the base file for partition: " + partitionPath
+            + ", fileId: " + fileId);
+      }
+
+      List<String> matchingKeys =
+          checkCandidatesAgainstFile(candidateRecordKeys, new Path(dataFile.get().getPath()));
+      LOG.debug(
+          String.format("Total records (%d), bloom filter candidates (%d)/fp(%d), actual matches (%d)",
+              hoodieKeyList.size(), candidateRecordKeys.size(),
+              candidateRecordKeys.size() - matchingKeys.size(), matchingKeys.size()));
+
+      ArrayList<MetaBloomIndexGroupedKeyLookupResult> subList = new ArrayList<>();
+      subList.add(new MetaBloomIndexGroupedKeyLookupResult(fileId, partitionPath, dataFile.get().getCommitTime(),
+          matchingKeys));
+      resultList.add(subList);
+    });
+
+    return resultList.iterator();
+  }
+
+  public List<String> checkCandidatesAgainstFile(List<String> candidateRecordKeys,
+                                                 Path latestDataFilePath) throws HoodieIndexException {
+    List<String> foundRecordKeys = new ArrayList<>();
+    try {
+      // Load all rowKeys from the file, to double-confirm
+      if (!candidateRecordKeys.isEmpty()) {
+        HoodieTimer timer = new HoodieTimer().startTimer();
+
+        final HoodieFileReader fileReader = HoodieFileReaderFactory.getFileReader(hoodieTable.getHadoopConf(),
+            latestDataFilePath);
+        Set<String> fileRowKeys = fileReader.filterRowKeys(new HashSet<>(candidateRecordKeys));
+        foundRecordKeys.addAll(fileRowKeys);
+        LOG.debug(String.format("Checked keys against file %s, in %d ms. #candidates (%d) #found (%d)",
+            latestDataFilePath,
+            timer.endTimer(), candidateRecordKeys.size(), foundRecordKeys.size()));
+        LOG.debug("Keys matching for file " + latestDataFilePath + " => " + foundRecordKeys);
+      }
+    } catch (Exception e) {
+      throw new HoodieIndexException("Error checking candidate keys against file.", e);
+    }
+    return foundRecordKeys;
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexColStatFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexColStatFunction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.avro.model.HoodieColumnStats;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Function performing actual checking of RDD partition containing (fileId, hoodieKeys) against the actual files.
+ */
+public class HoodieBloomMetaIndexColStatFunction
+    implements FlatMapFunction<Iterator<Tuple2<Tuple2<String, String>, HoodieKey>>, Tuple2<Tuple2<String, String>,
+    HoodieKey>> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieBloomMetaIndexColStatFunction.class);
+  private final HoodieTable hoodieTable;
+  private final HoodieWriteConfig config;
+
+  public HoodieBloomMetaIndexColStatFunction(HoodieTable hoodieTable, HoodieWriteConfig config) {
+    this.hoodieTable = hoodieTable;
+    this.config = config;
+  }
+
+  @Override
+  public Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> call(
+      Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tuple2Iterator) throws Exception {
+    Map<String, String> columnKeyHashToFileNameMap = new HashMap<>();
+    Map<String, List<HoodieKey>> columnKeyHashToHoodieKeysMap = new HashMap<>();
+    List<Tuple2<Tuple2<String, String>, HoodieKey>> result = new ArrayList<>();
+
+    while (tuple2Iterator.hasNext()) {
+      final Tuple2<Tuple2<String, String>, HoodieKey> entry = tuple2Iterator.next();
+      final String colStatKeyHash = entry._1._1;
+      final String fileName = entry._1._2;
+      final HoodieKey hoodieKey = entry._2;
+      columnKeyHashToHoodieKeysMap.computeIfAbsent(colStatKeyHash, e -> new ArrayList<>()).add(hoodieKey);
+      columnKeyHashToFileNameMap.putIfAbsent(colStatKeyHash, fileName);
+    }
+
+    Map<String, HoodieColumnStats> columnKeyHashToStatMap =
+        hoodieTable.getMetadataTable().getColumnStats(
+            columnKeyHashToHoodieKeysMap.keySet().stream().collect(Collectors.toList()));
+
+    for (Map.Entry<String, String> entry : columnKeyHashToFileNameMap.entrySet()) {
+      ValidationUtils.checkState(columnKeyHashToHoodieKeysMap.containsKey(entry.getKey()));
+      ValidationUtils.checkState(columnKeyHashToStatMap.containsKey(entry.getKey()));
+
+      final String fileName = entry.getValue();
+      final List<HoodieKey> keyList = columnKeyHashToHoodieKeysMap.get(entry.getKey());
+      final HoodieColumnStats keyColumnStat = columnKeyHashToStatMap.get(entry.getKey());
+
+      keyList.forEach(hoodieKey -> {
+        if ((Objects.requireNonNull(keyColumnStat.getMinValue()).compareTo(hoodieKey.getRecordKey()) <= 0)
+            && (Objects.requireNonNull(keyColumnStat.getMaxValue()).compareTo(hoodieKey.getRecordKey()) >= 0)) {
+          result.add(new Tuple2<>(new Tuple2<>(FSUtils.getFileId(fileName), fileName), hoodieKey));
+        }
+      });
+    }
+    return result.iterator();
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexLazyCheckFunction.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/index/bloom/HoodieBloomMetaIndexLazyCheckFunction.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.index.bloom;
+
+import org.apache.hudi.client.utils.LazyIterableIterator;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.io.HoodieKeyMetaBloomIndexLookupHandle;
+import org.apache.hudi.io.HoodieKeyMetaBloomIndexLookupHandle.MetaBloomIndexKeyLookupResult;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.function.Function2;
+import scala.Tuple2;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Function performing actual checking of RDD partition containing (fileId, hoodieKeys) against the actual files.
+ */
+public class HoodieBloomMetaIndexLazyCheckFunction
+    implements Function2<Integer, Iterator<Tuple2<Tuple2<String, String>, HoodieKey>>,
+    Iterator<List<MetaBloomIndexKeyLookupResult>>> {
+
+  private static final Logger LOG = LogManager.getLogger(HoodieBloomMetaIndexLazyCheckFunction.class);
+  private final HoodieTable hoodieTable;
+  private final HoodieWriteConfig config;
+
+  public HoodieBloomMetaIndexLazyCheckFunction(HoodieTable hoodieTable, HoodieWriteConfig config) {
+    this.hoodieTable = hoodieTable;
+    this.config = config;
+  }
+
+  @Override
+  public Iterator<List<MetaBloomIndexKeyLookupResult>> call(Integer integer,
+                                                            Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> tupleIterator) throws Exception {
+    return new LazyKeyCheckIterator(tupleIterator);
+  }
+
+  class LazyKeyCheckIterator extends LazyIterableIterator<Tuple2<Tuple2<String, String>, HoodieKey>,
+      List<MetaBloomIndexKeyLookupResult>> {
+
+    private HoodieKeyMetaBloomIndexLookupHandle keyLookupHandle;
+
+    LazyKeyCheckIterator(Iterator<Tuple2<Tuple2<String, String>, HoodieKey>> filePartitionRecordKeyTripletItr) {
+      super(filePartitionRecordKeyTripletItr);
+    }
+
+    @Override
+    protected void start() {
+    }
+
+    @Override
+    protected List<MetaBloomIndexKeyLookupResult> computeNext() {
+
+      List<MetaBloomIndexKeyLookupResult> ret = new ArrayList<>();
+      try {
+        // process one file in each go.
+        while (inputItr.hasNext()) {
+          Tuple2<Tuple2<String, String>, HoodieKey> currentTuple = inputItr.next();
+          final String fileName = currentTuple._1._1;
+          final String fileId = FSUtils.getFileId(fileName);
+          ValidationUtils.checkState(!fileId.isEmpty());
+          String partitionPath = currentTuple._2.getPartitionPath();
+          String recordKey = currentTuple._2.getRecordKey();
+          Pair<String, String> partitionPathFileIdPair = Pair.of(partitionPath, fileId);
+
+          // lazily init state
+          if (keyLookupHandle == null) {
+            keyLookupHandle = new HoodieKeyMetaBloomIndexLookupHandle(config, hoodieTable, partitionPathFileIdPair,
+                fileName);
+          }
+
+          // if continue on current file
+          if (keyLookupHandle.getPartitionPathFilePair().equals(partitionPathFileIdPair)) {
+            keyLookupHandle.addKey(recordKey);
+          } else {
+            // do the actual checking of file & break out
+            ret.add(keyLookupHandle.getLookupResult());
+            keyLookupHandle = new HoodieKeyMetaBloomIndexLookupHandle(config, hoodieTable, partitionPathFileIdPair,
+                fileName);
+            keyLookupHandle.addKey(recordKey);
+            break;
+          }
+        }
+
+        // handle case, where we ran out of input, close pending work, update return val
+        if (!inputItr.hasNext()) {
+          ret.add(keyLookupHandle.getLookupResult());
+        }
+      } catch (Throwable e) {
+        if (e instanceof HoodieException) {
+          throw e;
+        }
+        throw new HoodieIndexException("Error checking bloom filter index. ", e);
+      }
+
+      return ret;
+    }
+
+    @Override
+    protected void end() {
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -191,7 +191,6 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
             fileGroupCount));
         r.setCurrentLocation(new HoodieRecordLocation(slice.getBaseInstantTime(), slice.getFileId()));
         return r;
-
       });
 
       if (rddAllPartitionRecords == null) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -40,9 +40,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetadataWriter {
 
@@ -121,11 +123,11 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     }
   }
 
-  protected void commit(HoodieData<HoodieRecord> hoodieDataRecords, String partitionName, String instantTime, boolean canTriggerTableService) {
+  @Override
+  protected void commit(String instantTime, Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionRecordsMap, boolean canTriggerTableService) {
     ValidationUtils.checkState(metadataMetaClient != null, "Metadata table is not fully initialized yet.");
     ValidationUtils.checkState(enabled, "Metadata table cannot be committed to as it is not enabled");
-    JavaRDD<HoodieRecord> records = (JavaRDD<HoodieRecord>) hoodieDataRecords.get();
-    JavaRDD<HoodieRecord> recordRDD = prepRecords(records, partitionName, 1);
+    JavaRDD<HoodieRecord> recordRDD = prepRecords(partitionRecordsMap);
 
     try (SparkRDDWriteClient writeClient = new SparkRDDWriteClient(engineContext, metadataWriteConfig, true)) {
       if (!metadataMetaClient.getActiveTimeline().filterCompletedInstants().containsInstant(instantTime)) {
@@ -165,17 +167,41 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
 
   /**
    * Tag each record with the location in the given partition.
-   *
+   * <p>
    * The record is tagged with respective file slice's location based on its record key.
    */
-  private JavaRDD<HoodieRecord> prepRecords(JavaRDD<HoodieRecord> recordsRDD, String partitionName, int numFileGroups) {
-    List<FileSlice> fileSlices = HoodieTableMetadataUtil.getPartitionLatestFileSlices(metadataMetaClient, partitionName);
-    ValidationUtils.checkArgument(fileSlices.size() == numFileGroups, String.format("Invalid number of file groups: found=%d, required=%d", fileSlices.size(), numFileGroups));
+  private JavaRDD<HoodieRecord> prepRecords(Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionRecordsMap) {
+    // The result set
+    JavaRDD<HoodieRecord> rddAllPartitionRecords = null;
 
-    return recordsRDD.map(r -> {
-      FileSlice slice = fileSlices.get(HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(r.getRecordKey(), numFileGroups));
-      r.setCurrentLocation(new HoodieRecordLocation(slice.getBaseInstantTime(), slice.getFileId()));
-      return r;
-    });
+    for (Map.Entry<MetadataPartitionType, HoodieData<HoodieRecord>> entry : partitionRecordsMap.entrySet()) {
+      final String partitionName = entry.getKey().partitionPath();
+      final int fileGroupCount = entry.getKey().getFileGroupCount();
+      HoodieData<HoodieRecord> records = entry.getValue();
+      JavaRDD<HoodieRecord> recordsRDD = (JavaRDD<HoodieRecord>) records.get();
+
+      List<FileSlice> fileSlices =
+          HoodieTableMetadataUtil.getPartitionLatestFileSlices(metadataMetaClient, partitionName);
+      ValidationUtils.checkArgument(fileSlices.size() == fileGroupCount,
+          String.format("Invalid number of file groups: found=%d, required=%d", fileSlices.size(), fileGroupCount));
+
+      JavaSparkContext jsc = ((HoodieSparkEngineContext) engineContext).getJavaSparkContext();
+      JavaRDD<HoodieRecord> rddSinglePartitionRecords = recordsRDD.map(r -> {
+        FileSlice slice = fileSlices.get(HoodieTableMetadataUtil.mapRecordKeyToFileGroupIndex(r.getRecordKey(),
+            fileGroupCount));
+        r.setCurrentLocation(new HoodieRecordLocation(slice.getBaseInstantTime(), slice.getFileId()));
+        return r;
+
+      });
+
+      if (rddAllPartitionRecords == null) {
+        rddAllPartitionRecords = rddSinglePartitionRecords;
+
+      } else {
+        rddAllPartitionRecords = rddAllPartitionRecords.union(rddSinglePartitionRecords);
+
+      }
+    }
+    return rddAllPartitionRecords;
   }
 }

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieBackedMetadata.java
@@ -216,7 +216,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     testTable.doWriteOperation("0000003", UPSERT, emptyList(), asList("p1", "p2"), 1, true);
     syncTableMetadata(writeConfig);
 
-    List<String> partitions = metadataWriter(writeConfig).metadata().getAllPartitionPaths();
+    List<String> partitions = metadataWriter(writeConfig).getTableMetadata().getAllPartitionPaths();
     assertFalse(partitions.contains(nonPartitionDirectory),
         "Must not contain the non-partition " + nonPartitionDirectory);
     assertTrue(partitions.contains("p1"), "Must contain partition p1");
@@ -374,6 +374,82 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     assertEquals(tableMetadata.getLatestCompactionTime().get(), "0000004001");
   }
 
+  @ParameterizedTest
+  @EnumSource(HoodieTableType.class)
+  public void testTableOperationsWithMetaIndexLazyLoad(HoodieTableType tableType) throws Exception {
+    initPath();
+    HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .bloomIndexBucketizedChecking(false)
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withMetaIndexBloomFilter(true)
+            .withMetaIndexBloomFilterBatchLoad(false)
+            .withMetaIndexColumnStats(true)
+            .build())
+        .build();
+    init(tableType, writeConfig);
+    testTableOperationsForMetaIndexImpl(writeConfig);
+  }
+
+  @ParameterizedTest
+  @EnumSource(HoodieTableType.class)
+  public void testTableOperationsWithMetaIndexBatchLoad(HoodieTableType tableType) throws Exception {
+    initPath();
+    HoodieWriteConfig writeConfig = getWriteConfigBuilder(true, true, false)
+        .withIndexConfig(HoodieIndexConfig.newBuilder()
+            .bloomIndexBucketizedChecking(false)
+            .build())
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withMetaIndexBloomFilter(true)
+            .withMetaIndexBloomFilterBatchLoad(true)
+            .withMetaIndexColumnStats(true)
+            .build())
+        .build();
+    init(tableType, writeConfig);
+    testTableOperationsForMetaIndexImpl(writeConfig);
+  }
+
+  private void testTableOperationsForMetaIndexImpl(final HoodieWriteConfig writeConfig) throws Exception {
+    HoodieSparkEngineContext engineContext = new HoodieSparkEngineContext(jsc);
+
+    try (SparkRDDWriteClient client = new SparkRDDWriteClient(engineContext, writeConfig)) {
+      // Write 1 (Bulk insert)
+      String newCommitTime = "0000001";
+      List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 20);
+      client.startCommitWithTime(newCommitTime);
+      List<WriteStatus> writeStatuses = client.bulkInsert(jsc.parallelize(records, 1), newCommitTime).collect();
+      assertNoWriteErrors(writeStatuses);
+      validateMetadata(client);
+
+      // Write 2 (inserts)
+      newCommitTime = "0000002";
+      client.startCommitWithTime(newCommitTime);
+      validateMetadata(client);
+
+      records = dataGen.generateInserts(newCommitTime, 20);
+      writeStatuses = client.insert(jsc.parallelize(records, 1), newCommitTime).collect();
+      assertNoWriteErrors(writeStatuses);
+      validateMetadata(client);
+
+      // Write 3 (updates)
+      newCommitTime = "0000003";
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUniqueUpdates(newCommitTime, 10);
+      writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
+      assertNoWriteErrors(writeStatuses);
+
+      // Write 4 (updates and inserts)
+      newCommitTime = "0000004";
+      client.startCommitWithTime(newCommitTime);
+      records = dataGen.generateUpdates(newCommitTime, 10);
+      writeStatuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
+      assertNoWriteErrors(writeStatuses);
+      validateMetadata(client);
+    }
+  }
 
   /**
    * Tests that virtual key configs are honored in base files after compaction in metadata table.
@@ -1765,7 +1841,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     // in the .hoodie folder.
     List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, HoodieTableMetadata.getMetadataTableBasePath(basePath),
         false, false);
-    assertEquals(MetadataPartitionType.values().length, metadataTablePartitions.size());
+    assertEquals(metadataWriter.getEnabledPartitionTypes().size(), metadataTablePartitions.size());
 
     // Metadata table should automatically compact and clean
     // versions are +1 as autoclean / compaction happens end of commits

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/client/functional/TestHoodieMetadataBase.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.testutils.HoodieMetadataTestTable;
 import org.apache.hudi.common.testutils.HoodieTestTable;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieStorageConfig;
@@ -74,12 +75,22 @@ public class TestHoodieMetadataBase extends HoodieClientTestHarness {
     init(tableType, true);
   }
 
+  public void init(HoodieTableType tableType, HoodieWriteConfig writeConfig) throws IOException {
+    init(tableType, Option.of(writeConfig), true, false, false, false);
+  }
+
   public void init(HoodieTableType tableType, boolean enableMetadataTable) throws IOException {
     init(tableType, enableMetadataTable, true, false, false);
   }
 
   public void init(HoodieTableType tableType, boolean enableMetadataTable, boolean enableFullScan, boolean enableMetrics, boolean
-                   validateMetadataPayloadStateConsistency) throws IOException {
+      validateMetadataPayloadStateConsistency) throws IOException {
+    init(tableType, Option.empty(), enableMetadataTable, enableFullScan, enableMetrics,
+        validateMetadataPayloadStateConsistency);
+  }
+
+  public void init(HoodieTableType tableType, Option<HoodieWriteConfig> writeConfig, boolean enableMetadataTable,
+                   boolean enableFullScan, boolean enableMetrics, boolean validateMetadataPayloadStateConsistency) throws IOException {
     this.tableType = tableType;
     initPath();
     initSparkContexts("TestHoodieMetadata");
@@ -89,9 +100,12 @@ public class TestHoodieMetadataBase extends HoodieClientTestHarness {
     initMetaClient(tableType);
     initTestDataGenerator();
     metadataTableBasePath = HoodieTableMetadata.getMetadataTableBasePath(basePath);
-    writeConfig = getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true, enableMetadataTable, enableMetrics,
-        enableFullScan, true, validateMetadataPayloadStateConsistency).build();
-    initWriteConfigAndMetatableWriter(writeConfig, enableMetadataTable);
+    this.writeConfig = writeConfig.isPresent()
+        ? writeConfig.get() : getWriteConfigBuilder(HoodieFailedWritesCleaningPolicy.EAGER, true,
+        enableMetadataTable, enableMetrics, enableFullScan, true,
+        validateMetadataPayloadStateConsistency)
+        .build();
+    initWriteConfigAndMetatableWriter(this.writeConfig, enableMetadataTable);
   }
 
   protected void initWriteConfigAndMetatableWriter(HoodieWriteConfig writeConfig, boolean enableMetadataTable) {

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestHarness.java
@@ -59,7 +59,6 @@ import org.apache.hudi.metadata.FileSystemBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieBackedTableMetadataWriter;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataWriter;
-import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.metadata.SparkHoodieBackedTableMetadataWriter;
 import org.apache.hudi.table.HoodieSparkTable;
 import org.apache.hudi.table.HoodieTable;
@@ -680,7 +679,7 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness im
     // in the .hoodie folder.
     List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, HoodieTableMetadata.getMetadataTableBasePath(basePath),
         false, false);
-    Assertions.assertEquals(MetadataPartitionType.values().length, metadataTablePartitions.size());
+    Assertions.assertEquals(metadataWriter.getEnabledPartitionTypes().size(), metadataTablePartitions.size());
 
     // Metadata table should automatically compact and clean
     // versions are +1 as autoClean / compaction happens end of commits

--- a/hudi-common/src/main/avro/HoodieMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieMetadata.avsc
@@ -30,27 +30,118 @@
             "doc": "Type of the metadata record",
             "type": "int"
         },
-        {   "name": "filesystemMetadata",
+        {
             "doc": "Contains information about partitions and files within the dataset",
-            "type": ["null", {
-               "type": "map",
-               "values": {
+            "name": "filesystemMetadata",
+            "type": [
+                "null",
+                {
+                    "type": "map",
+                    "values": {
+                        "type": "record",
+                        "name": "HoodieMetadataFileInfo",
+                        "fields": [
+                            {
+                                "name": "size",
+                                "type": "long",
+                                "doc": "Size of the file"
+                            },
+                            {
+                                "name": "isDeleted",
+                                "type": "boolean",
+                                "doc": "True if this file has been deleted"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "doc": "Metadata Index of bloom filters for all data files in the user table",
+            "name": "BloomFilterMetadata",
+            "type": [
+                "null",
+                {
+                    "doc": "Data file bloom filter details",
+                    "name": "HoodieMetadataBloomFilter",
                     "type": "record",
-                    "name": "HoodieMetadataFileInfo",
                     "fields": [
                         {
-                            "name": "size",
-                            "type": "long",
-                            "doc": "Size of the file"
+                            "doc": "Bloom filter type code",
+                            "name": "type",
+                            "type": "string"
                         },
                         {
+                            "doc": "Instant timestamp when this metadata was created/updated",
+                            "name": "timestamp",
+                            "type": "string"
+                        },
+                        {
+                            "doc": "Bloom filter binary byte array",
+                            "name": "bloomFilter",
+                            "type": "bytes"
+                        },
+                        {
+                            "doc": "Bloom filter entry valid/deleted flag",
                             "name": "isDeleted",
-                            "type": "boolean",
-                            "doc": "True if this file has been deleted"
+                            "type": "boolean"
+                        },
+                        {
+                            "doc": "Reserved bytes for future use",
+                            "name": "reserved",
+                            "type": "bytes"
                         }
                     ]
                 }
-            }]
+            ]
+        },
+        {
+            "doc": "Metadata Index of column ranges for all data files in the user table",
+            "name": "ColumnStatsMetadata",
+            "type": [
+                "null",
+                {
+                    "doc": "Data file column ranges details",
+                    "name": "HoodieColumnStats",
+                    "type": "record",
+                    "fields": [
+                        {
+                            "doc": "Minimum value in the range. Based on user data table schema, we can convert this to appropriate type",
+                            "name": "minValue",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        {
+                            "doc": "Maximum value in the range. Based on user data table schema, we can convert it to appropriate type",
+                            "name": "maxValue",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        {
+                            "doc": "Maximum value in the range. Based on user data table schema, we can convert it to appropriate type",
+                            "name": "nullCount",
+                            "type": [
+                                "null",
+                                "long"
+                            ]
+                        },
+                        {
+                            "doc": "Column range entry valid/deleted flag",
+                            "name": "isDeleted",
+                            "type": "boolean"
+                        },
+                        {
+                            "doc": "Reserved bits for future use",
+                            "name": "reserved",
+                            "type": "bytes"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/HoodieDynamicBoundedBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/HoodieDynamicBoundedBloomFilter.java
@@ -63,7 +63,7 @@ public class HoodieDynamicBoundedBloomFilter implements BloomFilter {
    * @param serString the serialized string which represents the {@link HoodieDynamicBoundedBloomFilter}
    * @param typeCode  type code of the bloom filter
    */
-  HoodieDynamicBoundedBloomFilter(String serString, BloomFilterTypeCode typeCode) {
+  public HoodieDynamicBoundedBloomFilter(String serString, BloomFilterTypeCode typeCode) {
     // ignoring the type code for now, since we have just one version
     byte[] bytes = Base64CodecUtil.decode(serString);
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -140,6 +140,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
           + "enabled, a new partition under metadata table will be created to store the column ranges and will "
           + "used for pruning files during the index lookups.");
 
+  public static final ConfigProperty<Boolean> META_INDEX_COLUMN_STATS_FOR_ALL_COLUMNS = ConfigProperty
+      .key(METADATA_PREFIX + ".index.column.stats.all_columns")
+      .defaultValue(false)
+      .sinceVersion("0.11.0")
+      .withDocumentation("Enable indexing user data files column ranges under metadata table key lookups. When "
+          + "enabled, a new partition under metadata table will be created to store the column ranges and will "
+          + "used for pruning files during the index lookups.");
+
   public static final ConfigProperty<Boolean> ENABLE_META_INDEX_BLOOM_FILTER_BATCH_LOAD_MODE = ConfigProperty
       .key(METADATA_PREFIX + ".index.bloomfilter.batchload.enable")
       .defaultValue(false)
@@ -186,6 +194,10 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean isMetaIndexColumnStatsEnabled() {
     return getBooleanOrDefault(ENABLE_META_INDEX_COLUMN_STATS);
+  }
+
+  public boolean isMetaIndexColumnStatsForAllColumns() {
+    return getBooleanOrDefault(META_INDEX_COLUMN_STATS_FOR_ALL_COLUMNS);
   }
 
   public boolean isMetaIndexBloomFilterBatchLoadEnabled() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -150,7 +150,7 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public static final ConfigProperty<Boolean> ENABLE_META_INDEX_BLOOM_FILTER_BATCH_LOAD_MODE = ConfigProperty
       .key(METADATA_PREFIX + ".index.bloomfilter.batchload.enable")
-      .defaultValue(false)
+      .defaultValue(true)
       .sinceVersion("0.11.0")
       .withDocumentation("Enable batch/bulk loading of bloom filter index for the entire partition when looking "
           + "up index. This is useful when upserting large set of records under the same partition.");

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -124,6 +124,29 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("0.10.0")
       .withDocumentation("Enable full scanning of log files while reading log records. If disabled, hudi does look up of only interested entries.");
 
+  public static final ConfigProperty<Boolean> ENABLE_META_INDEX_BLOOM_FILTER = ConfigProperty
+      .key(METADATA_PREFIX + ".index.bloomfilter.enable")
+      .defaultValue(false)
+      .sinceVersion("0.11.0")
+      .withDocumentation("Enable indexing user data files bloom filters under metadata table. When enabled, "
+          + "a new partition under metadata table will be created to store the bloom filter index and will be "
+          + "used during the index lookups.");
+
+  public static final ConfigProperty<Boolean> ENABLE_META_INDEX_COLUMN_STATS = ConfigProperty
+      .key(METADATA_PREFIX + ".index.column.stats.enable")
+      .defaultValue(false)
+      .sinceVersion("0.11.0")
+      .withDocumentation("Enable indexing user data files column ranges under metadata table key lookups. When "
+          + "enabled, a new partition under metadata table will be created to store the column ranges and will "
+          + "used for pruning files during the index lookups.");
+
+  public static final ConfigProperty<Boolean> ENABLE_META_INDEX_BLOOM_FILTER_BATCH_LOAD_MODE = ConfigProperty
+      .key(METADATA_PREFIX + ".index.bloomfilter.batchload.enable")
+      .defaultValue(false)
+      .sinceVersion("0.11.0")
+      .withDocumentation("Enable batch/bulk loading of bloom filter index for the entire partition when looking "
+          + "up index. This is useful when upserting large set of records under the same partition.");
+
   public static final ConfigProperty<Boolean> POPULATE_META_FIELDS = ConfigProperty
       .key(METADATA_PREFIX + ".populate.meta.fields")
       .defaultValue(true)
@@ -155,6 +178,18 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
   public boolean enabled() {
     return getBoolean(ENABLE);
+  }
+
+  public boolean isMetaIndexBloomFilterEnabled() {
+    return getBooleanOrDefault(ENABLE_META_INDEX_BLOOM_FILTER);
+  }
+
+  public boolean isMetaIndexColumnStatsEnabled() {
+    return getBooleanOrDefault(ENABLE_META_INDEX_COLUMN_STATS);
+  }
+
+  public boolean isMetaIndexBloomFilterBatchLoadEnabled() {
+    return getBooleanOrDefault(ENABLE_META_INDEX_BLOOM_FILTER_BATCH_LOAD_MODE);
   }
 
   public boolean enableMetrics() {
@@ -196,6 +231,21 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder enable(boolean enable) {
       metadataConfig.setValue(ENABLE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder withMetaIndexBloomFilter(boolean enable) {
+      metadataConfig.setValue(ENABLE_META_INDEX_BLOOM_FILTER, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder withMetaIndexBloomFilterBatchLoad(boolean enable) {
+      metadataConfig.setValue(ENABLE_META_INDEX_BLOOM_FILTER_BATCH_LOAD_MODE, String.valueOf(enable));
+      return this;
+    }
+
+    public Builder withMetaIndexColumnStats(boolean enable) {
+      metadataConfig.setValue(ENABLE_META_INDEX_COLUMN_STATS, String.valueOf(enable));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnStatsMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieColumnStatsMetadata.java
@@ -1,0 +1,110 @@
+package org.apache.hudi.common.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Objects;
+
+/**
+ * Hoodie Column Stats metadata.
+ */
+public class HoodieColumnStatsMetadata<T> {
+
+  private final String partitionPath;
+  private final String filePath;
+  private final String columnName;
+  private final T minValue;
+  private final T maxValue;
+  private final long nullCount;
+  private final boolean isDeleted;
+
+  public HoodieColumnStatsMetadata(final String partitionPath, final String filePath, final String columnName,
+                                   final T minValue, final T maxValue, final long nullCount, final boolean isDeleted) {
+    this.partitionPath = partitionPath;
+    this.filePath = filePath;
+    this.columnName = columnName;
+    this.minValue = minValue;
+    this.maxValue = maxValue;
+    this.nullCount = nullCount;
+    this.isDeleted = isDeleted;
+  }
+
+  public String getPartitionPath() {
+    return partitionPath;
+  }
+
+  public String getFilePath() {
+    return this.filePath;
+  }
+
+  public String getColumnName() {
+    return this.columnName;
+  }
+
+  public T getMinValue() {
+    return this.minValue;
+  }
+
+  public T getMaxValue() {
+    return this.maxValue;
+  }
+
+  public long getNullCount() {
+    return this.nullCount;
+  }
+
+  public boolean isDeleted() {
+    return isDeleted;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HoodieColumnStatsMetadata<?> that = (HoodieColumnStatsMetadata<?>) o;
+    return Objects.equals(getPartitionPath(), that.getPartitionPath())
+        && Objects.equals(getFilePath(), that.getFilePath())
+        && Objects.equals(getColumnName(), that.getColumnName())
+        && Objects.equals(getMinValue(), that.getMinValue())
+        && Objects.equals(getMaxValue(), that.getMaxValue())
+        && Objects.equals(getNullCount(), that.getNullCount())
+        && Objects.equals(isDeleted(), that.isDeleted());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getColumnName(), getMinValue(), getMaxValue());
+  }
+
+  @Override
+  public String toString() {
+    return "HoodieColumnStatsMetadata{"
+        + "partitionPath: " + partitionPath
+        + ", filePath: " + filePath
+        + ", columnName: " + columnName
+        + ", minValue: " + minValue
+        + ", maxValue: " + maxValue
+        + ", nullCount: " + nullCount
+        + ", isDeleted: " + isDeleted + '}';
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieColumnRangeMetadata;
+import org.apache.hudi.common.model.HoodieColumnStatsMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.exception.HoodieIOException;
@@ -46,6 +47,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -380,4 +382,76 @@ public class ParquetUtils extends BaseFileUtils {
 
     return val;
   }
+
+  /**
+   * Parse min/max statistics stored in parquet footers for all columns.
+   */
+  public Collection<HoodieColumnStatsMetadata<Comparable>> readColumnStatsFromParquetMetadata(Configuration conf,
+                                                                                              String partitionPath,
+                                                                                              Path parquetFilePath,
+                                                                                              Option<List<String>> latestColumns) {
+
+    ParquetMetadata metadata = readMetadata(conf, parquetFilePath);
+    // collect stats from all parquet blocks
+    Map<String, List<HoodieColumnStatsMetadata<Comparable>>> columnToStatsListMap =
+        metadata.getBlocks().stream().flatMap(blockMetaData -> {
+          return blockMetaData.getColumns().stream().filter(columnChunkMetaData -> {
+            if (latestColumns.isPresent()) {
+              return latestColumns.get().contains(columnChunkMetaData.getPath().toDotString());
+
+            }
+            return true;
+          }).map(
+              columnChunkMetaData -> new HoodieColumnStatsMetadata<>(partitionPath, parquetFilePath.getName(),
+                  columnChunkMetaData.getPath().toDotString(),
+                  columnChunkMetaData.getStatistics().genericGetMin(),
+                  columnChunkMetaData.getStatistics().genericGetMax(),
+                  columnChunkMetaData.getStatistics().getNumNulls(),
+                  false)
+          );
+
+        }).collect(Collectors.groupingBy(e -> e.getColumnName()));
+
+    // we only intend to keep file level statistics (not per-block level statisitcs in index. In future, we can
+    // change to store row group level stats
+    // improve performance even more). So reduce above map to Map<column_name, column_range>
+    return new ArrayList<>(columnToStatsListMap.values().stream()
+        .map(blocks -> getColumnStatsFromFile(blocks))
+        .collect(Collectors.toList()));
+  }
+
+  private HoodieColumnStatsMetadata<Comparable> getColumnStatsFromFile(final List<HoodieColumnStatsMetadata<Comparable>> blockRanges) {
+    if (blockRanges.size() == 1) {
+      // only one block in parquet file. we can just return that range.
+      return blockRanges.get(0);
+    } else {
+      // there are multiple blocks. Compute min(block_mins) and max(block_maxs)
+      return blockRanges.stream().reduce((b1, b2) -> combineRanges(b1, b2)).get();
+    }
+  }
+
+  private HoodieColumnStatsMetadata<Comparable> combineRanges(HoodieColumnStatsMetadata<Comparable> range1,
+                                                              HoodieColumnStatsMetadata<Comparable> range2) {
+    final Comparable minValue;
+    final Comparable maxValue;
+    final long nullCount = range1.getNullCount() + range2.getNullCount();
+    if (range1.getMinValue() != null && range2.getMinValue() != null) {
+      minValue = range1.getMinValue().compareTo(range2.getMinValue()) < 0 ? range1.getMinValue() : range2.getMinValue();
+    } else if (range1.getMinValue() == null) {
+      minValue = range2.getMinValue();
+    } else {
+      minValue = range1.getMinValue();
+    }
+
+    if (range1.getMaxValue() != null && range2.getMaxValue() != null) {
+      maxValue = range1.getMaxValue().compareTo(range2.getMaxValue()) < 0 ? range2.getMaxValue() : range1.getMaxValue();
+    } else if (range1.getMaxValue() == null) {
+      maxValue = range2.getMaxValue();
+    } else {
+      maxValue = range1.getMaxValue();
+    }
+    return new HoodieColumnStatsMetadata<>(range1.getPartitionPath(), range1.getFilePath(), range1.getColumnName(),
+        minValue, maxValue, nullCount, false);
+  }
+
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -397,13 +397,12 @@ public class ParquetUtils extends BaseFileUtils {
         metadata.getBlocks().stream().flatMap(blockMetaData -> {
           return blockMetaData.getColumns().stream().filter(columnChunkMetaData -> {
             if (latestColumns.isPresent()) {
-              return latestColumns.get().contains(columnChunkMetaData.getPath().toDotString());
-
+              return latestColumns.get().contains(columnChunkMetaData.getPrimitiveType().getName());
             }
             return true;
           }).map(
               columnChunkMetaData -> new HoodieColumnStatsMetadata<>(partitionPath, parquetFilePath.getName(),
-                  columnChunkMetaData.getPath().toDotString(),
+                  columnChunkMetaData.getPrimitiveType().getName(),
                   columnChunkMetaData.getStatistics().genericGetMin(),
                   columnChunkMetaData.getStatistics().genericGetMax(),
                   columnChunkMetaData.getStatistics().getNumNulls(),

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/ColumnIndexID.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/ColumnIndexID.java
@@ -22,21 +22,28 @@ package org.apache.hudi.common.util.hash;
 import org.apache.hudi.common.util.Base64CodecUtil;
 
 /**
- * Hoodie object ID representing any partition.
+ * A stateful Hoodie object ID representing any table column.
  */
-public class PartitionID extends HoodieID {
+public class ColumnIndexID extends HoodieIndexID {
 
-  private static final Type TYPE = Type.PARTITION;
-  private static final HashID.Size ID_PARTITION_HASH_SIZE = HashID.Size.BITS_64;
+  private static final Type TYPE = Type.COLUMN;
+  public static final HashID.Size ID_COLUMN_HASH_SIZE = HashID.Size.BITS_64;
+  private final String column;
   private final byte[] hash;
 
-  public PartitionID(final String message) {
-    this.hash = HashID.hash(message, ID_PARTITION_HASH_SIZE);
+  public ColumnIndexID(final String column) {
+    this.column = column;
+    this.hash = HashID.hash(column, ID_COLUMN_HASH_SIZE);
+  }
+
+  @Override
+  public String getName() {
+    return column;
   }
 
   @Override
   public int bits() {
-    return ID_PARTITION_HASH_SIZE.byteSize();
+    return ID_COLUMN_HASH_SIZE.byteSize();
   }
 
   @Override
@@ -58,5 +65,4 @@ public class PartitionID extends HoodieID {
   protected Type getType() {
     return TYPE;
   }
-
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/FileIndexID.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/FileIndexID.java
@@ -22,21 +22,28 @@ package org.apache.hudi.common.util.hash;
 import org.apache.hudi.common.util.Base64CodecUtil;
 
 /**
- * A stateful Hoodie object ID representing any table column.
+ * Hoodie object ID representing any file.
  */
-public class ColumnID extends HoodieID {
+public class FileIndexID extends HoodieIndexID {
 
-  private static final Type TYPE = Type.COLUMN;
-  private static final HashID.Size ID_COLUMN_HASH_SIZE = HashID.Size.BITS_64;
+  private static final Type TYPE = Type.FILE;
+  private static final HashID.Size ID_FILE_HASH_SIZE = HashID.Size.BITS_128;
+  private final String fileName;
   private final byte[] hash;
 
-  public ColumnID(final String message) {
-    this.hash = HashID.hash(message, ID_COLUMN_HASH_SIZE);
+  public FileIndexID(final String fileName) {
+    this.fileName = fileName;
+    this.hash = HashID.hash(fileName, ID_FILE_HASH_SIZE);
+  }
+
+  @Override
+  public String getName() {
+    return fileName;
   }
 
   @Override
   public int bits() {
-    return ID_COLUMN_HASH_SIZE.byteSize();
+    return ID_FILE_HASH_SIZE.byteSize();
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/HoodieIndexID.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/HoodieIndexID.java
@@ -24,9 +24,10 @@ import org.apache.hudi.exception.HoodieNotSupportedException;
 import java.io.Serializable;
 
 /**
- * A serializable ID that can be used to identify any Hoodie table fields and resources.
+ * A serializable ID that can be used to identify any Hoodie table fields and
+ * resources in the on-disk index.
  */
-public abstract class HoodieID implements Serializable {
+public abstract class HoodieIndexID implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -49,6 +50,13 @@ public abstract class HoodieID implements Serializable {
       return "Type{name='" + name + "'}";
     }
   }
+
+  /**
+   * Get the resource name for which this index id is generated.
+   *
+   * @return The resource name
+   */
+  public abstract String getName();
 
   /**
    * Get the number of bits representing this ID in memory.
@@ -74,7 +82,7 @@ public abstract class HoodieID implements Serializable {
   public abstract String toString();
 
   /**
-   *
+   * Get the Base64 encoded version of the ID.
    */
   public String asBase64EncodedString() {
     throw new HoodieNotSupportedException("Unsupported hash for " + getType());

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/hash/PartitionIndexID.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/hash/PartitionIndexID.java
@@ -22,21 +22,28 @@ package org.apache.hudi.common.util.hash;
 import org.apache.hudi.common.util.Base64CodecUtil;
 
 /**
- * Hoodie object ID representing any file.
+ * Hoodie object ID representing any partition.
  */
-public class FileID extends HoodieID {
+public class PartitionIndexID extends HoodieIndexID {
 
-  private static final Type TYPE = Type.FILE;
-  private static final HashID.Size ID_FILE_HASH_SIZE = HashID.Size.BITS_128;
+  private static final Type TYPE = Type.PARTITION;
+  private static final HashID.Size ID_PARTITION_HASH_SIZE = HashID.Size.BITS_64;
+  private final String partition;
   private final byte[] hash;
 
-  public FileID(final String message) {
-    this.hash = HashID.hash(message, ID_FILE_HASH_SIZE);
+  public PartitionIndexID(final String partition) {
+    this.partition = partition;
+    this.hash = HashID.hash(partition, ID_PARTITION_HASH_SIZE);
+  }
+
+  @Override
+  public String getName() {
+    return partition;
   }
 
   @Override
   public int bits() {
-    return ID_FILE_HASH_SIZE.byteSize();
+    return ID_PARTITION_HASH_SIZE.byteSize();
   }
 
   @Override
@@ -58,4 +65,5 @@ public class FileID extends HoodieID {
   protected Type getType() {
     return TYPE;
   }
+
 }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileReader.java
@@ -20,6 +20,7 @@ package org.apache.hudi.io.storage;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.avro.Schema;
@@ -34,6 +35,10 @@ public interface HoodieFileReader<R extends IndexedRecord> {
   public BloomFilter readBloomFilter();
 
   public Set<String> filterRowKeys(Set<String> candidateRowKeys);
+
+  default Map<String, R> filterRecords(Set<String> candidateRowKeys) {
+    throw new UnsupportedOperationException();
+  }
 
   public Iterator<R> getRecordIterator(Schema readerSchema) throws IOException;
 

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieHFileReader.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -52,8 +52,11 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 
-public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileReader {
+public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileReader<R> {
+  private static final Logger LOG = LogManager.getLogger(HoodieHFileReader.class);
   private Path path;
   private Configuration conf;
   private HFile.Reader reader;
@@ -136,12 +139,17 @@ public class HoodieHFileReader<R extends IndexedRecord> implements HoodieFileRea
     // Current implementation reads all records and filters them. In certain cases, it many be better to:
     //  1. Scan a limited subset of keys (min/max range of candidateRowKeys)
     //  2. Lookup keys individually (if the size of candidateRowKeys is much less than the total keys in file)
+    return filterRecords(candidateRowKeys).keySet();
+  }
+
+  @Override
+  public HashMap<String, R> filterRecords(Set<String> candidateRowKeys) {
     try {
       List<Pair<String, R>> allRecords = readAllRecords();
-      Set<String> rowKeys = new HashSet<>();
+      HashMap<String, R> rowKeys = new HashMap<>();
       allRecords.forEach(t -> {
         if (candidateRowKeys.contains(t.getFirst())) {
-          rowKeys.add(t.getFirst());
+          rowKeys.put(t.getFirst(), t.getSecond());
         }
       });
       return rowKeys;

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/FileSystemBackedTableMetadata.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
@@ -29,8 +30,12 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -143,5 +148,21 @@ public class FileSystemBackedTableMetadata implements HoodieTableMetadata {
   @Override
   public void reset() {
     // no-op
+  }
+
+  public Option<ByteBuffer> getBloomFilter(final PartitionIndexID partitionIndexID, final FileIndexID fileIndexID)
+      throws HoodieMetadataException {
+    throw new HoodieMetadataException("Unsupported operation: getBloomFilter for " + fileIndexID.getName());
+  }
+
+  @Override
+  public Map<String, ByteBuffer> getBloomFilters(final List<Pair<PartitionIndexID, FileIndexID>> partitionFileIndexIDList)
+      throws HoodieMetadataException {
+    throw new HoodieMetadataException("Unsupported operation: getBloomFilters!");
+  }
+
+  @Override
+  public Map<String, HoodieColumnStats> getColumnStats(List<String> keySet) throws HoodieMetadataException {
+    throw new HoodieMetadataException("Unsupported operation: getColumnsStats!");
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -41,6 +41,8 @@ public class HoodieMetadataMetrics implements Serializable {
   // Metric names
   public static final String LOOKUP_PARTITIONS_STR = "lookup_partitions";
   public static final String LOOKUP_FILES_STR = "lookup_files";
+  public static final String LOOKUP_BLOOM_FILTERS_METADATA_STR = "lookup_meta_index_bloom_filters";
+  public static final String LOOKUP_COLUMN_STATS_METADATA_STR = "lookup_meta_index_column_ranges";
   public static final String SCAN_STR = "scan";
   public static final String BASEFILE_READ_STR = "basefile_read";
   public static final String INITIALIZE_STR = "initialize";
@@ -77,7 +79,7 @@ public class HoodieMetadataMetrics implements Serializable {
     Map<String, String> stats = new HashMap<>();
 
     // Total size of the metadata and count of base/log files
-    for (String metadataPartition : MetadataPartitionType.all()) {
+    for (String metadataPartition : MetadataPartitionType.allPaths()) {
       List<FileSlice> latestSlices = fsView.getLatestFileSlices(metadataPartition).collect(Collectors.toList());
 
       // Total size of the metadata and count of base/log files

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -23,6 +23,7 @@ import org.apache.hudi.avro.model.HoodieMetadataBloomFilter;
 import org.apache.hudi.avro.model.HoodieMetadataFileInfo;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieColumnStatsMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -403,7 +404,7 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
   public static String getColumnStatsRecordKey(HoodieColumnStatsMetadata<Comparable> columnStatsMetadata) {
     final ColumnIndexID columnID = new ColumnIndexID(columnStatsMetadata.getColumnName());
     final PartitionIndexID partitionID = new PartitionIndexID(columnStatsMetadata.getPartitionPath());
-    final FileIndexID fileID = new FileIndexID(columnStatsMetadata.getFilePath());
+    final FileIndexID fileID = new FileIndexID(FSUtils.getFileId(new Path(columnStatsMetadata.getFilePath()).getName()));
     return columnID.asBase64EncodedString()
         .concat(partitionID.asBase64EncodedString())
         .concat(fileID.asBase64EncodedString());

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -18,13 +18,21 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
+import org.apache.hudi.avro.model.HoodieMetadataBloomFilter;
 import org.apache.hudi.avro.model.HoodieMetadataFileInfo;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
+import org.apache.hudi.common.bloom.BloomFilterTypeCode;
+import org.apache.hudi.common.model.HoodieColumnStatsMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.hash.ColumnIndexID;
+import org.apache.hudi.common.util.hash.FileIndexID;
+
+import org.apache.hudi.common.util.hash.PartitionIndexID;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -33,9 +41,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.io.api.Binary;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,36 +56,64 @@ import java.util.stream.Stream;
 import static org.apache.hudi.metadata.HoodieTableMetadata.RECORDKEY_PARTITION_LIST;
 
 /**
- * This is a payload which saves information about a single entry in the Metadata Table.
- *
- * The type of the entry is determined by the "type" saved within the record. The following types of entries are saved:
- *
- *   1. List of partitions: There is a single such record
- *         key="__all_partitions__"
- *
- *   2. List of files in a Partition: There is one such record for each partition
- *         key=Partition name
- *
- *  During compaction on the table, the deletions are merged with additions and hence pruned.
- *
- * Metadata Table records are saved with the schema defined in HoodieMetadata.avsc. This class encapsulates the
- * HoodieMetadataRecord for ease of operations.
+ * MetadataTable records are persisted with the schema defined in HoodieMetadata.avsc.
+ * This class represents the payload for the MetadataTable.
+ * <p>
+ * This single metadata payload is shared by all the partitions under the metadata table.
+ * The partition specific records are determined by the field "type" saved within the record.
+ * The following types are supported:
+ * <p>
+ * METADATA_TYPE_PARTITION_LIST (1):
+ * -- List of all partitions. There is a single such record
+ * -- key = @{@link HoodieTableMetadata.RECORDKEY_PARTITION_LIST}
+ * <p>
+ * METADATA_TYPE_FILE_LIST (2):
+ * -- List of all files in a partition. There is one such record for each partition
+ * -- key = partition name
+ * <p>
+ * METADATA_TYPE_COLUMN_STATS (3):
+ * -- This is an index for column stats in the table
+ * <p>
+ * METADATA_TYPE_BLOOM_FILTER (4):
+ * -- This is an index for base file bloom filters. This is a map of FileID to its BloomFilter byte[].
+ * <p>
+ * During compaction on the table, the deletions are merged with additions and hence records are pruned.
  */
 public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadataPayload> {
+
+  // Type of the record. This can be an enum in the schema but Avro1.8
+  // has a bug - https://issues.apache.org/jira/browse/AVRO-1810
+  protected static final int METADATA_TYPE_PARTITION_LIST = 1;
+  protected static final int METADATA_TYPE_FILE_LIST = 2;
+  protected static final int METADATA_TYPE_COLUMN_STATS = 3;
+  protected static final int METADATA_TYPE_BLOOM_FILTER = 4;
 
   // HoodieMetadata schema field ids
   public static final String SCHEMA_FIELD_ID_KEY = "key";
   public static final String SCHEMA_FIELD_ID_TYPE = "type";
-  public static final String SCHEMA_FIELD_ID_METADATA = "filesystemMetadata";
+  public static final String SCHEMA_FIELD_ID_FILESYSTEM = "filesystemMetadata";
+  private static final String SCHEMA_FIELD_ID_COLUMN_STATS = "ColumnStatsMetadata";
+  private static final String SCHEMA_FIELD_ID_BLOOM_FILTER = "BloomFilterMetadata";
 
-  // Type of the record
-  // This can be an enum in the schema but Avro 1.8 has a bug - https://issues.apache.org/jira/browse/AVRO-1810
-  private static final int PARTITION_LIST = 1;
-  private static final int FILE_LIST = 2;
+  // HoodieMetadata bloom filter payload field ids
+  private static final String BLOOM_FILTER_FIELD_TYPE = "type";
+  private static final String BLOOM_FILTER_FIELD_TIMESTAMP = "timestamp";
+  private static final String BLOOM_FILTER_FIELD_BLOOM_FILTER = "bloomFilter";
+  private static final String BLOOM_FILTER_FIELD_IS_DELETED = "isDeleted";
+  private static final String BLOOM_FILTER_FIELD_RESERVED = "reserved";
+
+  // HoodieMetadata column stats payload field ids
+  private static final String COLUMN_STATS_FIELD_MIN_VALUE = "minValue";
+  private static final String COLUMN_STATS_FIELD_MAX_VALUE = "maxValue";
+  private static final String COLUMN_STATS_FIELD_NULL_COUNT = "nullCount";
+  private static final String COLUMN_STATS_FIELD_IS_DELETED = "isDeleted";
+  private static final String COLUMN_STATS_FIELD_RESERVED = "reserved";
 
   private String key = null;
   private int type = 0;
   private Map<String, HoodieMetadataFileInfo> filesystemMetadata = null;
+  private HoodieMetadataBloomFilter bloomFilterMetadata = null;
+  private HoodieColumnStats columnStatMetadata = null;
 
   public HoodieMetadataPayload(GenericRecord record, Comparable<?> orderingVal) {
     this(Option.of(record));
@@ -86,20 +125,65 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
       // https://issues.apache.org/jira/browse/AVRO-1811
       key = record.get().get(SCHEMA_FIELD_ID_KEY).toString();
       type = (int) record.get().get(SCHEMA_FIELD_ID_TYPE);
-      if (record.get().get(SCHEMA_FIELD_ID_METADATA) != null) {
-        filesystemMetadata = (Map<String, HoodieMetadataFileInfo>) record.get().get("filesystemMetadata");
+      if (record.get().get(SCHEMA_FIELD_ID_FILESYSTEM) != null) {
+        filesystemMetadata = (Map<String, HoodieMetadataFileInfo>) record.get().get(SCHEMA_FIELD_ID_FILESYSTEM);
         filesystemMetadata.keySet().forEach(k -> {
           GenericRecord v = filesystemMetadata.get(k);
           filesystemMetadata.put(k.toString(), new HoodieMetadataFileInfo((Long) v.get("size"), (Boolean) v.get("isDeleted")));
         });
       }
+
+      if (type == METADATA_TYPE_BLOOM_FILTER) {
+        final GenericRecord metadataRecord = (GenericRecord) record.get().get(SCHEMA_FIELD_ID_BLOOM_FILTER);
+        if (metadataRecord == null) {
+          throw new HoodieMetadataException("Valid " + SCHEMA_FIELD_ID_BLOOM_FILTER + " record expected for type: " + METADATA_TYPE_BLOOM_FILTER);
+        }
+        bloomFilterMetadata = new HoodieMetadataBloomFilter(
+            (String) metadataRecord.get(BLOOM_FILTER_FIELD_TYPE),
+            (String) metadataRecord.get(BLOOM_FILTER_FIELD_TIMESTAMP),
+            (ByteBuffer) metadataRecord.get(BLOOM_FILTER_FIELD_BLOOM_FILTER),
+            (Boolean) metadataRecord.get(BLOOM_FILTER_FIELD_IS_DELETED),
+            (ByteBuffer) metadataRecord.get(BLOOM_FILTER_FIELD_RESERVED)
+        );
+      }
+
+      if (type == METADATA_TYPE_COLUMN_STATS) {
+        GenericRecord v = (GenericRecord) record.get().get(SCHEMA_FIELD_ID_COLUMN_STATS);
+        if (v == null) {
+          throw new HoodieMetadataException("Valid " + SCHEMA_FIELD_ID_COLUMN_STATS + " record expected for type: " + METADATA_TYPE_COLUMN_STATS);
+        }
+        columnStatMetadata = new HoodieColumnStats(
+            (String) v.get(COLUMN_STATS_FIELD_MIN_VALUE),
+            (String) v.get(COLUMN_STATS_FIELD_MAX_VALUE),
+            (Long) v.get(COLUMN_STATS_FIELD_NULL_COUNT),
+            (Boolean) v.get(COLUMN_STATS_FIELD_IS_DELETED),
+            (ByteBuffer) v.get(COLUMN_STATS_FIELD_RESERVED)
+        );
+      }
     }
   }
 
   private HoodieMetadataPayload(String key, int type, Map<String, HoodieMetadataFileInfo> filesystemMetadata) {
+    this(key, type, filesystemMetadata, null, null);
+  }
+
+  private HoodieMetadataPayload(String key, int type, HoodieMetadataBloomFilter metadataBloomFilter) {
+    this(key, type, null, metadataBloomFilter, null);
+  }
+
+  private HoodieMetadataPayload(String key, int type, HoodieColumnStats columnStats) {
+    this(key, type, null, null, columnStats);
+  }
+
+  protected HoodieMetadataPayload(String key, int type,
+                                  Map<String, HoodieMetadataFileInfo> filesystemMetadata,
+                                  HoodieMetadataBloomFilter metadataBloomFilter,
+                                  HoodieColumnStats columnStats) {
     this.key = key;
     this.type = type;
     this.filesystemMetadata = filesystemMetadata;
+    this.bloomFilterMetadata = metadataBloomFilter;
+    this.columnStatMetadata = columnStats;
   }
 
   /**
@@ -109,55 +193,92 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    */
   public static HoodieRecord<HoodieMetadataPayload> createPartitionListRecord(List<String> partitions) {
     Map<String, HoodieMetadataFileInfo> fileInfo = new HashMap<>();
-    partitions.forEach(partition -> fileInfo.put(partition, new HoodieMetadataFileInfo(0L,  false)));
+    partitions.forEach(partition -> fileInfo.put(partition, new HoodieMetadataFileInfo(0L, false)));
 
     HoodieKey key = new HoodieKey(RECORDKEY_PARTITION_LIST, MetadataPartitionType.FILES.partitionPath());
-    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), PARTITION_LIST, fileInfo);
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), METADATA_TYPE_PARTITION_LIST,
+        fileInfo);
     return new HoodieRecord<>(key, payload);
   }
 
   /**
    * Create and return a {@code HoodieMetadataPayload} to save list of files within a partition.
    *
-   * @param partition The name of the partition
-   * @param filesAdded Mapping of files to their sizes for files which have been added to this partition
+   * @param partition    The name of the partition
+   * @param filesAdded   Mapping of files to their sizes for files which have been added to this partition
    * @param filesDeleted List of files which have been deleted from this partition
    */
   public static HoodieRecord<HoodieMetadataPayload> createPartitionFilesRecord(String partition,
-                                                                               Option<Map<String, Long>> filesAdded, Option<List<String>> filesDeleted) {
+                                                                               Option<Map<String, Long>> filesAdded,
+                                                                               Option<List<String>> filesDeleted) {
     Map<String, HoodieMetadataFileInfo> fileInfo = new HashMap<>();
     filesAdded.ifPresent(
         m -> m.forEach((filename, size) -> fileInfo.put(filename, new HoodieMetadataFileInfo(size, false))));
     filesDeleted.ifPresent(
-        m -> m.forEach(filename -> fileInfo.put(filename, new HoodieMetadataFileInfo(0L,  true))));
+        m -> m.forEach(filename -> fileInfo.put(filename, new HoodieMetadataFileInfo(0L, true))));
 
     HoodieKey key = new HoodieKey(partition, MetadataPartitionType.FILES.partitionPath());
-    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), FILE_LIST, fileInfo);
+    HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), METADATA_TYPE_FILE_LIST, fileInfo);
     return new HoodieRecord<>(key, payload);
+  }
+
+  /**
+   * Create bloom filter metadata record.
+   *
+   * @param fileID      - FileID for which the bloom filter needs to persisted
+   * @param timestamp   - Instant timestamp responsible for this record
+   * @param bloomFilter - Bloom filter for the File
+   * @param isDeleted   - Is the bloom filter no more valid
+   * @return Metadata payload containing the fileID and its bloom filter record
+   */
+  public static HoodieRecord<HoodieMetadataPayload> createBloomFilterMetadataRecord(final PartitionIndexID partitionID,
+                                                                                    final FileIndexID fileID,
+                                                                                    final String timestamp,
+                                                                                    final ByteBuffer bloomFilter,
+                                                                                    final boolean isDeleted) {
+    final String bloomFilterKey = partitionID.asBase64EncodedString().concat(fileID.asBase64EncodedString());
+    HoodieKey key = new HoodieKey(bloomFilterKey, MetadataPartitionType.BLOOM_FILTERS.partitionPath());
+
+    // TODO: Get the bloom filter type from the file
+    HoodieMetadataBloomFilter metadataBloomFilter =
+        new HoodieMetadataBloomFilter(BloomFilterTypeCode.DYNAMIC_V0.name(),
+            timestamp, bloomFilter, isDeleted, ByteBuffer.allocate(0));
+    HoodieMetadataPayload metadataPayload = new HoodieMetadataPayload(key.getRecordKey(),
+        HoodieMetadataPayload.METADATA_TYPE_BLOOM_FILTER, metadataBloomFilter);
+    return new HoodieRecord<>(key, metadataPayload);
   }
 
   @Override
   public HoodieMetadataPayload preCombine(HoodieMetadataPayload previousRecord) {
     ValidationUtils.checkArgument(previousRecord.type == type,
-        "Cannot combine " + previousRecord.type  + " with " + type);
-
-    Map<String, HoodieMetadataFileInfo> combinedFileInfo = null;
+        "Cannot combine " + previousRecord.type + " with " + type);
 
     switch (type) {
-      case PARTITION_LIST:
-      case FILE_LIST:
-        combinedFileInfo = combineFilesystemMetadata(previousRecord);
-        break;
+      case METADATA_TYPE_PARTITION_LIST:
+      case METADATA_TYPE_FILE_LIST:
+        Map<String, HoodieMetadataFileInfo> combinedFileInfo = combineFilesystemMetadata(previousRecord);
+        return new HoodieMetadataPayload(key, type, combinedFileInfo);
+      case METADATA_TYPE_BLOOM_FILTER:
+        HoodieMetadataBloomFilter combineBloomFilterMetadata = combineBloomFilterMetadata(previousRecord);
+        return new HoodieMetadataPayload(key, type, combineBloomFilterMetadata);
+      case METADATA_TYPE_COLUMN_STATS:
+        return new HoodieMetadataPayload(key, type, combineColumnStats(previousRecord));
       default:
         throw new HoodieMetadataException("Unknown type of HoodieMetadataPayload: " + type);
     }
+  }
 
-    return new HoodieMetadataPayload(key, type, combinedFileInfo);
+  private HoodieMetadataBloomFilter combineBloomFilterMetadata(HoodieMetadataPayload previousRecord) {
+    return this.bloomFilterMetadata;
+  }
+
+  private HoodieColumnStats combineColumnStats(HoodieMetadataPayload previousRecord) {
+    return this.columnStatMetadata;
   }
 
   @Override
   public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord oldRecord, Schema schema) throws IOException {
-    HoodieMetadataPayload anotherPayload = new HoodieMetadataPayload(Option.of((GenericRecord)oldRecord));
+    HoodieMetadataPayload anotherPayload = new HoodieMetadataPayload(Option.of((GenericRecord) oldRecord));
     HoodieRecordPayload combinedPayload = preCombine(anotherPayload);
     return combinedPayload.getInsertValue(schema);
   }
@@ -168,7 +289,8 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
       return Option.empty();
     }
 
-    HoodieMetadataRecord record = new HoodieMetadataRecord(key, type, filesystemMetadata);
+    HoodieMetadataRecord record = new HoodieMetadataRecord(key, type, filesystemMetadata, bloomFilterMetadata,
+        columnStatMetadata);
     return Option.of(record);
   }
 
@@ -184,6 +306,28 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
    */
   public List<String> getDeletions() {
     return filterFileInfoEntries(true).map(Map.Entry::getKey).sorted().collect(Collectors.toList());
+  }
+
+  /**
+   * Get the bloom filter metadata from this payload.
+   */
+  public Option<HoodieMetadataBloomFilter> getBloomFilterMetadata() {
+    if (bloomFilterMetadata == null) {
+      return Option.empty();
+    }
+
+    return Option.of(bloomFilterMetadata);
+  }
+
+  /**
+   * Get the bloom filter metadata from this payload.
+   */
+  public Option<HoodieColumnStats> getColumnStatMetadata() {
+    if (columnStatMetadata == null) {
+      return Option.empty();
+    }
+
+    return Option.of(columnStatMetadata);
   }
 
   /**
@@ -232,6 +376,44 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     }
 
     return combinedFileInfo;
+  }
+
+  public static Stream<HoodieRecord> createColumnStatsRecords(
+      Collection<HoodieColumnStatsMetadata<Comparable>> columnRangeInfo) {
+    return columnRangeInfo.stream().map(columnStatsMetadata -> {
+      HoodieKey key = new HoodieKey(getColumnStatsRecordKey(columnStatsMetadata),
+          MetadataPartitionType.COLUMN_STATS.partitionPath());
+
+      HoodieMetadataPayload payload = new HoodieMetadataPayload(key.getRecordKey(), METADATA_TYPE_COLUMN_STATS,
+          HoodieColumnStats.newBuilder()
+              .setMinValue(columnStatsMetadata.getMinValue() == null ? null :
+                  new String(((Binary) columnStatsMetadata.getMinValue()).getBytes()))
+              .setMaxValue(columnStatsMetadata.getMaxValue() == null ? null :
+                  new String(((Binary) columnStatsMetadata.getMaxValue()).getBytes()))
+              .setNullCount(columnStatsMetadata.getNullCount())
+              .setIsDeleted(false)
+              .setReserved(ByteBuffer.allocate(0))
+              .build());
+
+      return new HoodieRecord<>(key, payload);
+    });
+  }
+
+  // get record key from column stats metadata
+  public static String getColumnStatsRecordKey(HoodieColumnStatsMetadata<Comparable> columnStatsMetadata) {
+    final ColumnIndexID columnID = new ColumnIndexID(columnStatsMetadata.getColumnName());
+    final PartitionIndexID partitionID = new PartitionIndexID(columnStatsMetadata.getPartitionPath());
+    final FileIndexID fileID = new FileIndexID(columnStatsMetadata.getFilePath());
+    return columnID.asBase64EncodedString()
+        .concat(partitionID.asBase64EncodedString())
+        .concat(fileID.asBase64EncodedString());
+  }
+
+  // parse attribute in record key. TODO: find better way to get this attribute instaed of parsing key
+  public static String getAttributeFromRecordKey(String recordKey, String attribute) {
+    final String columnIDBase64EncodedString = recordKey.substring(0, ColumnIndexID.ID_COLUMN_HASH_SIZE.bits());
+
+    return "";
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataPayload.java
@@ -423,6 +423,20 @@ public class HoodieMetadataPayload implements HoodieRecordPayload<HoodieMetadata
     sb.append(SCHEMA_FIELD_ID_TYPE + "=").append(type).append(", ");
     sb.append("creations=").append(Arrays.toString(getFilenames().toArray())).append(", ");
     sb.append("deletions=").append(Arrays.toString(getDeletions().toArray())).append(", ");
+    if (type == METADATA_TYPE_BLOOM_FILTER) {
+      ValidationUtils.checkState(getBloomFilterMetadata().isPresent());
+      sb.append("BloomFilter: {");
+      sb.append("bloom size: " + getBloomFilterMetadata().get().getBloomFilter().array().length).append(", ");
+      sb.append("timestamp: " + getBloomFilterMetadata().get().getTimestamp()).append(", ");
+      sb.append("deleted: " + getBloomFilterMetadata().get().getIsDeleted());
+      sb.append("}");
+    }
+    if (type == METADATA_TYPE_COLUMN_STATS) {
+      ValidationUtils.checkState(getColumnStatMetadata().isPresent());
+      sb.append("ColStats: {");
+      sb.append(getColumnStatMetadata().get());
+      sb.append("}");
+    }
     sb.append('}');
     return sb.toString();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadata.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieColumnStats;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.SerializableConfiguration;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -25,9 +26,14 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.exception.HoodieMetadataException;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
@@ -103,6 +109,37 @@ public interface HoodieTableMetadata extends Serializable, AutoCloseable {
    * Fetch all files for given partition paths.
    */
   Map<String, FileStatus[]> getAllFilesInPartitions(List<String> partitionPaths) throws IOException;
+
+  /**
+   * Get the bloom filter for the FileID from the metadata table.
+   *
+   * @param partitionIndexID
+   * @param fileIndexID      - FileID for which bloom filter needs to be retrieved
+   * @return BloomFilter byte buffer if available, otherwise empty
+   * @throws HoodieMetadataException
+   */
+  Option<ByteBuffer> getBloomFilter(final PartitionIndexID partitionIndexID, final FileIndexID fileIndexID)
+      throws HoodieMetadataException;
+
+  /**
+   * Get bloom filters for the list of FileIDs from the metadata table.
+   *
+   * @param partitionFileIndexIDList - List of FileIDs for which bloom filters need to be retrieved
+   * @return Map of FileID to its bloom filter byte buffer
+   * @throws HoodieMetadataException
+   */
+  Map<String, ByteBuffer> getBloomFilters(final List<Pair<PartitionIndexID, FileIndexID>> partitionFileIndexIDList)
+      throws HoodieMetadataException;
+
+  /**
+   * TODO: Comment.
+   *
+   * @param keyList
+   * @param keySet
+   * @return
+   * @throws HoodieMetadataException
+   */
+  Map<String, HoodieColumnStats> getColumnStats(final List<String> keySet) throws HoodieMetadataException;
 
   /**
    * Get the instant time to which the metadata is synced w.r.t data timeline.

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -18,31 +18,49 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodieList;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieColumnStatsMetadata;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieDeltaWriteStat;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ParquetUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieMetadataException;
-
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
+import org.apache.hudi.io.storage.HoodieFileReader;
+import org.apache.hudi.io.storage.HoodieFileReaderFactory;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -62,12 +80,37 @@ public class HoodieTableMetadataUtil {
 
   private static final Logger LOG = LogManager.getLogger(HoodieTableMetadataUtil.class);
 
+  protected static final String PARTITION_NAME_FILES = "files";
+  protected static final String PARTITION_NAME_COLUMN_STATS = "column_stats";
+  protected static final String PARTITION_NAME_BLOOM_FILTERS = "bloom_filters";
+
   /**
-   * Delete the metadata table for the dataset. This will be invoked during upgrade/downgrade operation during which no other
+   * TODO: Comment.
+   *
+   * @param partitionPath
+   * @return
+   */
+  public static Option<MetadataPartitionType> fromPartitionPath(final String partitionPath) {
+    switch (partitionPath) {
+      case PARTITION_NAME_FILES:
+        return Option.of(MetadataPartitionType.FILES);
+      case PARTITION_NAME_COLUMN_STATS:
+        return Option.of(MetadataPartitionType.COLUMN_STATS);
+      case PARTITION_NAME_BLOOM_FILTERS:
+        return Option.of(MetadataPartitionType.BLOOM_FILTERS);
+      default:
+        LOG.error("Unexpected Partition path " + partitionPath);
+        return Option.empty();
+    }
+  }
+
+  /**
+   * Delete the metadata table for the dataset. This will be invoked during upgrade/downgrade operation during which
+   * no other
    * process should be running.
    *
    * @param basePath base path of the dataset
-   * @param context instance of {@link HoodieEngineContext}.
+   * @param context  instance of {@link HoodieEngineContext}.
    */
   public static void deleteMetadataTable(String basePath, HoodieEngineContext context) {
     final String metadataTablePath = HoodieTableMetadata.getMetadataTableBasePath(basePath);
@@ -80,13 +123,51 @@ public class HoodieTableMetadataUtil {
   }
 
   /**
+   * Convert commit action to metadata records for the enabled partition types.
+   *
+   * @param commitMetadata - Commit action metadata
+   * @param dataMetaClient - Meta client for the data table
+   * @param instantTime    - Action instant time
+   * @return Map of partition to metadata records for the commit action
+   */
+  public static Map<MetadataPartitionType, HoodieData<HoodieRecord>> convertMetadataToRecords(
+      HoodieEngineContext context, List<MetadataPartitionType> enabledPartitionTypes,
+      HoodieCommitMetadata commitMetadata, HoodieTableMetaClient dataMetaClient, String instantTime) {
+    final Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
+    final HoodieData<HoodieRecord> filesPartitionRecordsRDD = context.parallelize(
+        convertMetadataToFilesPartitionRecords(commitMetadata, instantTime), 1);
+    partitionToRecordsMap.put(MetadataPartitionType.FILES, filesPartitionRecordsRDD);
+
+    if (enabledPartitionTypes.contains(MetadataPartitionType.BLOOM_FILTERS)) {
+      final List<HoodieRecord> metadataBloomFilterRecords = convertMetadataToBloomFilterRecords(commitMetadata,
+          dataMetaClient, instantTime);
+      if (!metadataBloomFilterRecords.isEmpty()) {
+        final HoodieData<HoodieRecord> metadataBloomFilterRecordsRDD = context.parallelize(metadataBloomFilterRecords, 1);
+        partitionToRecordsMap.put(MetadataPartitionType.BLOOM_FILTERS, metadataBloomFilterRecordsRDD);
+      }
+    }
+
+    if (enabledPartitionTypes.contains(MetadataPartitionType.COLUMN_STATS)) {
+      final List<HoodieRecord> metadataColumnStats = convertMetadataToColumnStatsRecords(commitMetadata, context,
+          dataMetaClient, instantTime);
+      if (!metadataColumnStats.isEmpty()) {
+        final HoodieData<HoodieRecord> metadataColumnStatsRDD = context.parallelize(metadataColumnStats, 1);
+        partitionToRecordsMap.put(MetadataPartitionType.COLUMN_STATS, metadataColumnStatsRDD);
+      }
+    }
+
+    return partitionToRecordsMap;
+  }
+
+  /**
    * Finds all new files/partitions created as part of commit and creates metadata table records for them.
    *
-   * @param commitMetadata
-   * @param instantTime
-   * @return a list of metadata table records
+   * @param commitMetadata - Commit action metadata
+   * @param instantTime    - Commit action instant time
+   * @return List of metadata table records
    */
-  public static List<HoodieRecord> convertMetadataToRecords(HoodieCommitMetadata commitMetadata, String instantTime) {
+  public static List<HoodieRecord> convertMetadataToFilesPartitionRecords(HoodieCommitMetadata commitMetadata,
+                                                                          String instantTime) {
     List<HoodieRecord> records = new LinkedList<>();
     List<String> allPartitions = new LinkedList<>();
     commitMetadata.getPartitionToWriteStats().forEach((partitionStatName, writeStats) -> {
@@ -125,13 +206,85 @@ public class HoodieTableMetadataUtil {
   }
 
   /**
+   * Convert commit action metadata to bloom filter records.
+   *
+   * @param commitMetadata - Commit action metadata
+   * @param dataMetaClient - Meta client for the data table
+   * @param instantTime    - Action instant time
+   * @return List of metadata table records
+   */
+  public static List<HoodieRecord> convertMetadataToBloomFilterRecords(HoodieCommitMetadata commitMetadata,
+                                                                       HoodieTableMetaClient dataMetaClient,
+                                                                       String instantTime) {
+    List<HoodieRecord> records = new LinkedList<>();
+    commitMetadata.getPartitionToWriteStats().forEach((partitionStatName, writeStats) -> {
+      final String partition = partitionStatName.equals(EMPTY_PARTITION_NAME) ? NON_PARTITIONED_NAME : partitionStatName;
+      Map<String, Long> newFiles = new HashMap<>(writeStats.size());
+      writeStats.forEach(hoodieWriteStat -> {
+        // No action for delta logs
+        if (hoodieWriteStat instanceof HoodieDeltaWriteStat) {
+          return;
+        }
+
+        String pathWithPartition = hoodieWriteStat.getPath();
+        if (pathWithPartition == null) {
+          // Empty partition
+          LOG.error("Failed to find path in write stat to update metadata table " + hoodieWriteStat);
+          return;
+        }
+
+        int offset = partition.equals(NON_PARTITIONED_NAME) ? (pathWithPartition.startsWith("/") ? 1 : 0) :
+            partition.length() + 1;
+
+        String filename = pathWithPartition.substring(offset);
+        ValidationUtils.checkState(!newFiles.containsKey(filename), "Duplicate files in HoodieCommitMetadata");
+        Path writeFilePath = new Path(dataMetaClient.getBasePath(), pathWithPartition);
+        try {
+          HoodieFileReader<IndexedRecord> fileReader =
+              HoodieFileReaderFactory.getFileReader(dataMetaClient.getHadoopConf(), writeFilePath);
+          final BloomFilter fileBloomFilter = fileReader.readBloomFilter();
+          if (fileBloomFilter == null) {
+            LOG.error("Failed to read bloom filter for " + writeFilePath);
+            return;
+          }
+          ByteBuffer bloomByteBuffer = ByteBuffer.wrap(fileBloomFilter.serializeToString().getBytes());
+          // TODO: Improve the schema to include the filter type also
+          HoodieRecord record = HoodieMetadataPayload.createBloomFilterMetadataRecord(
+              new PartitionIndexID(partition), new FileIndexID(filename), instantTime, bloomByteBuffer, true);
+          records.add(record);
+          fileReader.close();
+        } catch (IOException e) {
+          LOG.error("Failed to get bloom filter for file: " + writeFilePath + ", write stat: " + hoodieWriteStat);
+        }
+      });
+    });
+
+    return records;
+  }
+
+  /**
+   * Convert the clean action to metadata records.
+   */
+  public static Map<MetadataPartitionType, HoodieData<HoodieRecord>> convertMetadataToRecords(
+      HoodieEngineContext engineContext, List<MetadataPartitionType> enabledPartitionTypes,
+      HoodieCleanMetadata cleanMetadata, String instantTime) {
+    final Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
+    final HoodieData<HoodieRecord> filesPartitionRecordsRDD = engineContext.parallelize(
+        convertMetadataToFilesPartitionRecords(cleanMetadata, enabledPartitionTypes, instantTime), 1);
+    partitionToRecordsMap.put(MetadataPartitionType.FILES, filesPartitionRecordsRDD);
+    return partitionToRecordsMap;
+  }
+
+  /**
    * Finds all files that were deleted as part of a clean and creates metadata table records for them.
    *
    * @param cleanMetadata
    * @param instantTime
    * @return a list of metadata table records
    */
-  public static List<HoodieRecord> convertMetadataToRecords(HoodieCleanMetadata cleanMetadata, String instantTime) {
+  public static List<HoodieRecord> convertMetadataToFilesPartitionRecords(HoodieCleanMetadata cleanMetadata,
+                                                                          List<MetadataPartitionType> enabledPartitionTypes,
+                                                                          String instantTime) {
     List<HoodieRecord> records = new LinkedList<>();
     int[] fileDeleteCount = {0};
     cleanMetadata.getPartitionMetadata().forEach((partitionName, partitionMetadata) -> {
@@ -151,31 +304,61 @@ public class HoodieTableMetadataUtil {
   }
 
   /**
+   * TODO: Comment.
+   */
+  public static Map<MetadataPartitionType, HoodieData<HoodieRecord>> convertMetadataToRecords(
+      HoodieEngineContext engineContext, List<MetadataPartitionType> enabledPartitionTypes,
+      HoodieActiveTimeline metadataTableTimeline, HoodieRestoreMetadata restoreMetadata, String instantTime,
+      Option<String> lastSyncTs) {
+    Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
+    partitionToRecordsMap.put(MetadataPartitionType.FILES, convertMetadataToRestoreRecords(
+        engineContext, metadataTableTimeline, restoreMetadata, instantTime, lastSyncTs));
+    return partitionToRecordsMap;
+  }
+
+  /**
    * Aggregates all files deleted and appended to from all rollbacks associated with a restore operation then
    * creates metadata table records for them.
    *
+   * @param engineContext
    * @param restoreMetadata
    * @param instantTime
    * @return a list of metadata table records
    */
-  public static List<HoodieRecord> convertMetadataToRecords(HoodieActiveTimeline metadataTableTimeline,
-                                                            HoodieRestoreMetadata restoreMetadata, String instantTime, Option<String> lastSyncTs) {
+  public static HoodieData<HoodieRecord> convertMetadataToRestoreRecords(HoodieEngineContext engineContext, HoodieActiveTimeline metadataTableTimeline,
+                                                                         HoodieRestoreMetadata restoreMetadata,
+                                                                         String instantTime, Option<String> lastSyncTs) {
     Map<String, Map<String, Long>> partitionToAppendedFiles = new HashMap<>();
     Map<String, List<String>> partitionToDeletedFiles = new HashMap<>();
     restoreMetadata.getHoodieRestoreMetadata().values().forEach(rms -> {
       rms.forEach(rm -> processRollbackMetadata(metadataTableTimeline, rm, partitionToDeletedFiles, partitionToAppendedFiles, lastSyncTs));
     });
 
-    return convertFilesToRecords(partitionToDeletedFiles, partitionToAppendedFiles, instantTime, "Restore");
+    return engineContext.parallelize(convertFilesToRecords(partitionToDeletedFiles, partitionToAppendedFiles, instantTime, "Restore"), 1);
   }
 
-  public static List<HoodieRecord> convertMetadataToRecords(HoodieActiveTimeline metadataTableTimeline,
-                                                            HoodieRollbackMetadata rollbackMetadata, String instantTime,
-                                                            Option<String> lastSyncTs, boolean wasSynced) {
+  /**
+   * TODO: Comment.
+   */
+  public static Map<MetadataPartitionType, HoodieData<HoodieRecord>> convertMetadataToRecords(
+      HoodieEngineContext engineContext, List<MetadataPartitionType> enabledPartitionTypes,
+      HoodieActiveTimeline metadataTableTimeline, HoodieRollbackMetadata rollbackMetadata, String instantTime,
+      Option<String> lastSyncTs, boolean wasSynced) {
+    final Map<MetadataPartitionType, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
+    final HoodieData<HoodieRecord> rollbackRecordsRDD = engineContext.parallelize(convertMetadataToRollbackRecords(
+        metadataTableTimeline, rollbackMetadata, instantTime, lastSyncTs, wasSynced), 1);
+    partitionToRecordsMap.put(MetadataPartitionType.FILES, rollbackRecordsRDD);
+    return partitionToRecordsMap;
+  }
 
+  public static List<HoodieRecord> convertMetadataToRollbackRecords(HoodieActiveTimeline metadataTableTimeline,
+                                                                    HoodieRollbackMetadata rollbackMetadata,
+                                                                    String instantTime,
+                                                                    Option<String> lastSyncTs, boolean wasSynced) {
     Map<String, Map<String, Long>> partitionToAppendedFiles = new HashMap<>();
     Map<String, List<String>> partitionToDeletedFiles = new HashMap<>();
-    processRollbackMetadata(metadataTableTimeline, rollbackMetadata, partitionToDeletedFiles, partitionToAppendedFiles, lastSyncTs);
+    processRollbackMetadata(metadataTableTimeline, rollbackMetadata, partitionToDeletedFiles,
+        partitionToAppendedFiles, lastSyncTs);
     if (!wasSynced) {
       // Since the instant-being-rolled-back was never committed to the metadata table, the files added there
       // need not be deleted. For MOR Table, the rollback appends logBlocks so we need to keep the appended files.
@@ -397,6 +580,111 @@ public class HoodieTableMetadataUtil {
       fileSliceStream = fsView.getLatestFileSlices(partition);
     }
     return fileSliceStream.sorted((s1, s2) -> s1.getFileId().compareTo(s2.getFileId())).collect(Collectors.toList());
+  }
+
+  public static List<HoodieRecord> convertMetadataToColumnStatsRecords(HoodieCommitMetadata commitMetadata,
+                                                                       HoodieEngineContext engineContext,
+                                                                       HoodieTableMetaClient dataMetaClient,
+                                                                       String instantTime) {
+
+    try {
+      List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
+          .flatMap(entry -> entry.stream()).collect(Collectors.toList());
+      //TODO this result may be too large to fit into memory. We may need to convert to dataframe and move this to
+      // spark-client
+      return HoodieTableMetadataUtil.createColumnStatsFromWriteStats(engineContext, dataMetaClient, allWriteStats);
+    } catch (Exception e) {
+      throw new HoodieException("Failed to generate column stats records for metadata table ", e);
+    }
+  }
+
+  public static HoodieData<HoodieRecord> convertMetadataToColumnStatsRecords(HoodieCleanMetadata cleanMetadata,
+                                                                             HoodieEngineContext engineContext,
+                                                                             HoodieTableMetaClient datasetMetaClient,
+                                                                             String instantTime) throws Exception {
+    List<Pair<String, String>> deleteFileInfos = new ArrayList<>();
+    cleanMetadata.getPartitionMetadata().forEach((partition, partitionMetadata) -> {
+      // Files deleted from a partition
+      List<String> deletedFiles = partitionMetadata.getDeletePathPatterns();
+      deletedFiles.forEach(entry -> deleteFileInfos.add(Pair.of(partition, entry)));
+    });
+
+    List<String> latestColumns = getLatestColumns(datasetMetaClient);
+    return HoodieList.of(engineContext.flatMap(deleteFileInfos,
+        deleteFileInfo -> getColumnStats(deleteFileInfo.getKey(), deleteFileInfo.getValue(), datasetMetaClient,
+            Option.of(latestColumns), true),
+        deleteFileInfos.size()));
+  }
+
+  /**
+   * @param engineContext
+   * @param datasetMetaClient
+   * @param allWriteStats
+   * @return a Map < Pair (partition path, file path)> -> collection of stats >
+   */
+  public static List<HoodieRecord> createColumnStatsFromWriteStats(HoodieEngineContext engineContext,
+                                                                   HoodieTableMetaClient datasetMetaClient,
+                                                                   List<HoodieWriteStat> allWriteStats) throws Exception {
+    if (allWriteStats.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<HoodieWriteStat> prunedWriteStats = allWriteStats.stream().filter(writeStat -> {
+      return !(writeStat instanceof HoodieDeltaWriteStat);
+    }).collect(Collectors.toList());
+    if (prunedWriteStats.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    // Considering only HoodieRecord.RECORD_KEY_METADATA_FIELD for index lookup
+    // TODO: Use all latest columns for full col index build and lookup
+    return engineContext.flatMap(prunedWriteStats,
+        writeStat -> translateWriteStatToColumnStats(writeStat, datasetMetaClient,
+            Option.of(Collections.singletonList(HoodieRecord.RECORD_KEY_METADATA_FIELD))), prunedWriteStats.size());
+  }
+
+  private static List<String> getLatestColumns(HoodieTableMetaClient datasetMetaClient) throws Exception {
+    if (datasetMetaClient.getCommitsTimeline().filterCompletedInstants().countInstants() > 1) {
+      TableSchemaResolver schemaResolver = new TableSchemaResolver(datasetMetaClient);
+      // consider nested fields as well.
+      // if column stats is enabled only for a subset of columns, directly use them instead of all columns from
+      // latest table schema
+      return schemaResolver.getTableAvroSchema().getFields().stream().map(entry -> entry.name()).collect(Collectors.toList());
+
+    } else {
+      return Collections.emptyList();
+
+    }
+  }
+
+  public static Stream<HoodieRecord> translateWriteStatToColumnStats(HoodieWriteStat writeStat,
+                                                                     HoodieTableMetaClient datasetMetaClient,
+                                                                     Option<List<String>> latestColumns) throws Exception {
+    return getColumnStats(writeStat.getPartitionPath(), writeStat.getPath(), datasetMetaClient, latestColumns, false);
+
+  }
+
+  public static Stream<HoodieRecord> getColumnStats(final String partitionPath, final String path,
+                                                    HoodieTableMetaClient datasetMetaClient,
+                                                    Option<List<String>> latestColumns,
+                                                    boolean isDeleted) throws Exception {
+    if (path.endsWith(HoodieFileFormat.PARQUET.getFileExtension())) {
+      //TODO: we are capturing range for most columns in the schema. Should we have allowList/denyList to reduce
+      // storage size of index?
+      Collection<HoodieColumnStatsMetadata<Comparable>> columnStatsMetadata = new ArrayList<>();
+      if (!isDeleted) {
+        columnStatsMetadata = new ParquetUtils().readColumnStatsFromParquetMetadata(
+            datasetMetaClient.getHadoopConf(), partitionPath, new Path(datasetMetaClient.getBasePath(), path),
+            latestColumns);
+      } else {
+        columnStatsMetadata =
+            latestColumns.get().stream().map(entry -> new HoodieColumnStatsMetadata<Comparable>(partitionPath, path,
+                entry, null, null, 0, true)).collect(Collectors.toList());
+      }
+      return HoodieMetadataPayload.createColumnStatsRecords(columnStatsMetadata);
+    } else {
+      throw new HoodieException("range index not supported for path " + path);
+    }
   }
 
 }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -22,27 +22,53 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum MetadataPartitionType {
-  FILES("files", "files-");
+  // TODO: Make the file group count configurable or auto compute based on the scaling needs
+  FILES(HoodieTableMetadataUtil.PARTITION_NAME_FILES, "files-", 1),
+  COLUMN_STATS(HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS, "col-stats-", 1),
+  BLOOM_FILTERS(HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS, "bloom-filters-", 1);
 
-  // refers to partition path in metadata table.
+  // Partition path in metadata table.
   private final String partitionPath;
-  // refers to fileId prefix used for all file groups in this partition.
+  // FileId prefix used for all file groups in this partition.
   private final String fileIdPrefix;
+  // Total file groups
+  private final int fileGroupCount;
 
-  MetadataPartitionType(String partitionPath, String fileIdPrefix) {
+  MetadataPartitionType(final String partitionPath, final String fileIdPrefix, final int fileGroupCount) {
     this.partitionPath = partitionPath;
     this.fileIdPrefix = fileIdPrefix;
+    this.fileGroupCount = fileGroupCount;
   }
 
   public String partitionPath() {
     return partitionPath;
   }
 
+  public String getPartitionPath() {
+    return partitionPath();
+  }
+
   public String getFileIdPrefix() {
     return fileIdPrefix;
   }
 
-  public static List<String> all() {
-    return Arrays.asList(MetadataPartitionType.FILES.partitionPath());
+  public int getFileGroupCount() {
+    return this.fileGroupCount;
+  }
+
+  public static List<String> allPaths() {
+    return Arrays.asList(
+        FILES.partitionPath(),
+        COLUMN_STATS.partitionPath(),
+        BLOOM_FILTERS.partitionPath()
+    );
+  }
+
+  public static List<MetadataPartitionType> allTypes() {
+    return Arrays.asList(
+        FILES,
+        COLUMN_STATS,
+        BLOOM_FILTERS
+    );
   }
 }

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/MetaIndexBenchmark.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/MetaIndexBenchmark.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.integ.testsuite;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.util.HoodieTimer;
+import org.apache.hudi.common.util.ParquetUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.util.hash.FileIndexID;
+import org.apache.hudi.common.util.hash.PartitionIndexID;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.utilities.IdentitySplitter;
+import org.apache.hudi.utilities.UtilHelpers;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.TaskContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Benchmark test for loading bloom filters directly from parquet files vs
+ * loading bloom filters from metadata table based bloom index.
+ */
+public class MetaIndexBenchmark implements Serializable {
+  private static volatile Logger LOG = LoggerFactory.getLogger(MetaIndexBenchmark.class);
+
+  private final transient HoodieTestSuiteConfig cfg;
+  private final transient JavaSparkContext jsc;
+  private transient SparkSession sparkSession;
+  private transient FileSystem fs;
+  private TypedProperties props;
+
+  public MetaIndexBenchmark(HoodieTestSuiteConfig cfg, JavaSparkContext jsc) {
+    this.cfg = cfg;
+    this.jsc = jsc;
+    this.sparkSession = SparkSession.builder().config(jsc.getConf()).enableHiveSupport().getOrCreate();
+    if (!cfg.propsFilePath.isEmpty()) {
+      this.fs = FSUtils.getFs(cfg.propsFilePath, jsc.hadoopConfiguration());
+      this.props = UtilHelpers.readConfig(fs.getConf(), new Path(cfg.propsFilePath), cfg.configs).getProps();
+    }
+  }
+
+  public static void main(String[] args) {
+    final HoodieTestSuiteConfig cfg = new HoodieTestSuiteConfig();
+    JCommander cmd = new JCommander(cfg, args);
+    if (cfg.help || args.length == 0) {
+      cmd.usage();
+      System.exit(1);
+    }
+
+    JavaSparkContext jssc = UtilHelpers.buildSparkContext("meta-index-benchmark", cfg.sparkMaster);
+    new MetaIndexBenchmark(cfg, jssc).runBenchmark();
+  }
+
+  public void runBenchmark() {
+    HoodieTimer timer = new HoodieTimer().startTimer();
+    try {
+      runTestSuiteImpl();
+    } catch (Exception e) {
+      throw new HoodieException("Failed to run Test Suite ", e);
+    } finally {
+      stopQuietly();
+    }
+    long timeTaken = timer.endTimer();
+    LOG.info("Benchmark time taken: " + timeTaken + " ms  / " + (timeTaken / 1000.0)
+        + " sec / " + (timeTaken / (1000.0 * 60)) + " min");
+  }
+
+  private void runTestSuiteImpl() throws IOException {
+    LOG.error("XXX Cfg\nParquetPathList : " + cfg.parquetPathList
+        + "\n NumPartitions: " + cfg.numPartitions
+        + "\n TableBasePath: " + cfg.basePath
+        + "\n Props: " + cfg.propsFilePath
+        + "\n: SparkMaster: " + cfg.sparkMaster);
+    if (!cfg.parquetPathList.isEmpty()) {
+      loadParquetBloomFilters();
+    }
+
+    if (!cfg.basePath.isEmpty()) {
+      loadMetaIndexBloomFilters();
+    }
+  }
+
+  private void loadParquetBloomFilters() {
+    JavaRDD<String> parquetPathListRDD;
+    if (this.cfg.numPartitions > 0) {
+      parquetPathListRDD = this.jsc.textFile(cfg.parquetPathList, this.cfg.numPartitions);
+    } else {
+      parquetPathListRDD = this.jsc.textFile(cfg.parquetPathList);
+    }
+
+    parquetPathListRDD.foreach(parquetPath -> {
+      readBloomFilter(new Configuration(), parquetPath);
+    });
+  }
+
+  private void readBloomFilter(Configuration config, final String parquetFilepath) {
+    final Pair<String, Long> id = getExecutorAndTaskID();
+    ParquetUtils.getInstance(HoodieFileFormat.PARQUET).readBloomFilterFromMetadata(config, new Path(parquetFilepath));
+    LOG.info("Executor[" + id.getLeft() + ", " + id.getRight() + "] loaded bloom filter from: " + parquetFilepath);
+  }
+
+  private Pair<String, Long> getExecutorAndTaskID() {
+    TaskContext tc = TaskContext.get();
+    SparkEnv sparkEnv = SparkEnv.get();
+    return Pair.of((sparkEnv != null ? sparkEnv.executorId() : "NA"),
+        (tc != null ? tc.taskAttemptId() : 0));
+  }
+
+  private void loadMetaIndexBloomFilters() throws IOException {
+    final int maxKeysForBloomIndexLookup = 2048;
+    LOG.info("Opening hudi table: " + cfg.basePath + " with props: " + this.props);
+    HoodieMetadataConfig config = HoodieMetadataConfig.newBuilder()
+        .fromProperties(this.props)
+        .build();
+    HoodieBackedTableMetadata metadata = new HoodieBackedTableMetadata(
+        new HoodieLocalEngineContext(new Configuration()),
+        config, cfg.basePath, "/tmp");
+    LOG.info("All partitions: " + metadata.getAllPartitionPaths());
+
+    List<Pair<PartitionIndexID, FileIndexID>> partitionFileKeyList = new ArrayList<>();
+    List<Pair<String, String>> partitionFileList = new ArrayList<>();
+    metadata.getAllPartitionPaths().forEach(partition -> {
+      try {
+        Arrays.stream(metadata.getAllFilesInPartition(new Path(cfg.basePath, partition))).forEach(fileStatus -> {
+          if (partitionFileKeyList.size() < maxKeysForBloomIndexLookup) {
+            partitionFileList.add(Pair.of(partition, FSUtils.getFileId(fileStatus.getPath().getName())));
+            partitionFileKeyList.add(Pair.of(new PartitionIndexID(partition),
+                new FileIndexID(FSUtils.getFileId(fileStatus.getPath().getName()))));
+          }
+        });
+      } catch (IOException e) {
+        LOG.error("Error loading meta index bloom filters: ", e);
+      }
+    });
+
+    LOG.info("All partitions and files: " + partitionFileList.subList(0, Math.min(partitionFileList.size(), 32)));
+    HoodieTimer timer = new HoodieTimer().startTimer();
+    Map<String, ByteBuffer> fileIDToBloomFilterByteBufferMap = metadata.getBloomFilters(partitionFileKeyList);
+    LOG.info("Loaded bloom filters: " + fileIDToBloomFilterByteBufferMap.size());
+
+    long timeTaken = timer.endTimer();
+    LOG.info("Bloom filter loading time taken: " + timeTaken + " ms  / " + (timeTaken / 1000.0)
+        + " sec / " + (timeTaken / (1000.0 * 60)) + " min");
+  }
+
+  private void stopQuietly() {
+    try {
+      jsc.stop();
+    } catch (Exception e) {
+      LOG.error("Unable to stop spark session", e);
+    }
+  }
+
+  public static class HoodieTestSuiteConfig {
+    @Parameter(names = {"--parquet-path-list"}, description = "Parquet path list")
+    public String parquetPathList = "";
+
+    @Parameter(names = {"--base-path"}, description = "Hudi table base path")
+    public String basePath = "";
+
+    @Parameter(names = {"--num-partitions"},
+        description = "Total number of partitions to split the input parquet path list", required = false)
+    public Integer numPartitions = 0;
+
+    @Parameter(names = {"--props"}, description = "path to properties file")
+    public String propsFilePath = "";
+
+    @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file",
+        splitter = IdentitySplitter.class)
+    public List<String> configs = new ArrayList<>();
+
+    @Parameter(names = {"--spark-master"}, description = "spark master to use.")
+    public String sparkMaster = "local[2]";
+
+    @Parameter(names = {"--help", "-h"}, help = true)
+    public Boolean help = false;
+  }
+}

--- a/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/MetadataTableTestSuiteJob.java
+++ b/hudi-integ-test/src/main/java/org/apache/hudi/integ/testsuite/MetadataTableTestSuiteJob.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.integ.testsuite;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.HFile;
+import org.apache.hadoop.hbase.io.hfile.HFileScanner;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.utilities.IdentitySplitter;
+import org.apache.hudi.utilities.UtilHelpers;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Test for reading records directly from HBase HFile.
+ */
+public class MetadataTableTestSuiteJob {
+  private static volatile Logger LOG = LoggerFactory.getLogger(MetadataTableTestSuiteJob.class);
+
+  private final transient JavaSparkContext jsc;
+  private final transient SparkSession sparkSession;
+  private final transient FileSystem fs;
+  private final HoodieTestSuiteConfig cfg;
+  private final Random random;
+  TypedProperties props;
+
+  public MetadataTableTestSuiteJob(HoodieTestSuiteConfig cfg, JavaSparkContext jsc) throws IOException {
+    this.cfg = cfg;
+    this.jsc = jsc;
+    this.sparkSession = SparkSession.builder().config(jsc.getConf()).enableHiveSupport().getOrCreate();
+    this.fs = FSUtils.getFs(cfg.hfilePath, jsc.hadoopConfiguration());
+    this.props = UtilHelpers.readConfig(fs.getConf(), new Path(cfg.propsFilePath), cfg.configs).getProps();
+    this.random = new Random();
+    this.random.setSeed(System.currentTimeMillis());
+  }
+
+  public static void main(String[] args) throws Exception {
+    final HoodieTestSuiteConfig cfg = new HoodieTestSuiteConfig();
+    JCommander cmd = new JCommander(cfg, args);
+    if (cfg.help || args.length == 0) {
+      cmd.usage();
+      System.exit(1);
+    }
+
+    JavaSparkContext jssc = UtilHelpers.buildSparkContext("metadata-hfile-reader", cfg.sparkMaster);
+    new MetadataTableTestSuiteJob(cfg, jssc).runTestSuite();
+  }
+
+  public void runTestSuite() {
+    try {
+      runTestSuiteImpl();
+    } catch (Exception e) {
+      throw new HoodieException("Failed to run Test Suite ", e);
+    } finally {
+      stopQuietly();
+    }
+  }
+
+  private void runTestSuiteImpl() throws InterruptedException, IOException {
+    LOG.error("XXX Cfg\nHFile: " + cfg.hfilePath
+        + "\n Props: " + cfg.propsFilePath
+        + "\n: SparkMaster: " + cfg.sparkMaster);
+    scan();
+  }
+
+  private void scan() throws InterruptedException, IOException {
+    LOG.info("Opening HFile reader for " + cfg.hfilePath);
+    final Path hfilePath = new Path(cfg.hfilePath);
+    final CacheConfig cacheConfig = new CacheConfig(jsc.hadoopConfiguration());
+
+    HFile.Reader reader = HFile.createReader(
+        FSUtils.getFs(hfilePath.toString(), jsc.hadoopConfiguration()),
+        hfilePath, cacheConfig, jsc.hadoopConfiguration());
+    HFileScanner scanner = null;
+
+    LOG.error("XXX Cfg scanAll: " + cfg.scanAll
+        + ", scanRandom: " + cfg.scanRandomKeys
+        + ", scanCount: " + cfg.scanCount
+        + ", reuseScanner: " + cfg.enableReuseScanner
+        + ", cache: " + cfg.enableCacheBlocks
+        + ", pread: " + cfg.enablePread);
+
+    int i = 0;
+    boolean scannerAvailable = false;
+    while (i++ < cfg.scanCount) {
+      if (cfg.scanAll) {
+        LOG.info("Scanning all keys");
+        if (!scannerAvailable || !cfg.enableReuseScanner) {
+          LOG.info("Opening HFile scanner");
+          scanner = reader.getScanner(cfg.enableCacheBlocks, cfg.enablePread);
+          scannerAvailable = true;
+        }
+        scanAll(scanner);
+      }
+
+      if (cfg.scanRandomKeys) {
+        if (!scannerAvailable || !cfg.enableReuseScanner) {
+          LOG.info("Opening HFile scanner");
+          scanner = reader.getScanner(cfg.enableCacheBlocks, cfg.enablePread);
+          scannerAvailable = true;
+        }
+        scanRandom(scanner);
+      }
+
+      if (cfg.readDelayBetweenKeysRead > 0) {
+        LOG.info("Scan delay " + cfg.readDelayBetweenKeysRead + "ms");
+        Thread.sleep(cfg.readDelayBetweenKeysRead);
+      }
+    }
+  }
+
+  private void scanAll(HFileScanner scanner) throws IOException {
+    if (scanner.seekTo()) {
+      do {
+        Cell c = scanner.getKeyValue();
+        byte[] keyBytes = Arrays.copyOfRange(c.getRowArray(), c.getRowOffset(), c.getRowOffset() + c.getRowLength());
+        LOG.info("Read key: " + new String(keyBytes));
+      } while (scanner.next());
+    } else {
+      LOG.error("Failed to seekTo()");
+      return;
+    }
+  }
+
+  private void scanRandom(HFileScanner scanner) throws IOException {
+    final String key = getRandomKey();
+    KeyValue kv = new KeyValue(key.getBytes(), null, null, null);
+    if (scanner.seekTo(kv) == 0) {
+      Cell c = scanner.getKeyValue();
+      Arrays.copyOfRange(c.getValueArray(), c.getValueOffset(), c.getValueOffset() + c.getValueLength());
+      LOG.info("Read random key: " + key);
+    } else {
+      LOG.error("Failed to seekTo(vk): " + key);
+    }
+  }
+
+  private String getRandomKey() {
+    final int choice = random.nextInt(10);
+
+    // 10%
+    if (cfg.useNonExistingKeys && choice == 0) {
+      return UUID.randomUUID().toString();
+    }
+
+    // 20%
+    if (choice < 2) {
+      return "__all_partitions__";
+    }
+
+    // rest all
+    final int month = random.nextInt(2) + 1;
+    StringBuilder key = new StringBuilder("1970/0");
+    key.append(month);
+    key.append("/");
+
+    final int suffix = (month == 1 ? (random.nextInt(31) + 1) : (random.nextInt(19) + 1));
+    key.append(String.format("%02d", suffix));
+    return key.toString();
+  }
+
+  private void stopQuietly() {
+    try {
+      jsc.stop();
+    } catch (Exception e) {
+      LOG.error("Unable to stop spark session", e);
+    }
+  }
+
+  public static class HoodieTestSuiteConfig {
+    @Parameter(names = {"--hfile-path"}, description = "HFile path", required = true)
+    public String hfilePath = "s3a://dl-scale-test/manoj/010RC2/integration-test-large-scale/sanity-10rounds/mor/output/"
+        + ".hoodie/metadata/files/files-0000_0-644-4247_20211201022415024001.hfile";
+
+    @Parameter(names = {"--scan-all"}, description = "Scan all keys")
+    public Boolean scanAll = false;
+
+    @Parameter(names = {"--scan-random-keys"}, description = "Seek to random keys")
+    public Boolean scanRandomKeys = false;
+
+    @Parameter(names = {"--scan-keys-count"}, description = "Total number of random keys read")
+    public Integer scanCount = 1;
+
+    @Parameter(names = {"--delay-between-keys-read"}, description = "Delay between read in millis")
+    public Integer readDelayBetweenKeysRead = 0;
+
+    @Parameter(names = {"--enable-reuse-scanner"}, description = "Reuse the existing scanner for all iterations")
+    public Boolean enableReuseScanner = false;
+
+    @Parameter(names = {"--enable-cache-blocks"}, description = "Reuse the existing scanner for all iterations")
+    public Boolean enableCacheBlocks = false;
+
+    @Parameter(names = {"--enable-pread"}, description = "Reuse the existing scanner for all iterations")
+    public Boolean enablePread = false;
+
+    @Parameter(names = {"--use-non-existing-keys"}, description = "Reuse the existing scanner for all iterations")
+    public Boolean useNonExistingKeys = false;
+
+    @Parameter(names = {"--props"}, description = "path to properties file")
+    public String propsFilePath = "";
+
+    @Parameter(names = {"--hoodie-conf"}, description = "Any configuration that can be set in the properties file",
+        splitter = IdentitySplitter.class)
+    public List<String> configs = new ArrayList<>();
+
+    @Parameter(names = {"--spark-master"}, description = "spark master to use.")
+    public String sparkMaster = "local[2]";
+
+    @Parameter(names = {"--help", "-h"}, help = true)
+    public Boolean help = false;
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

 - MetaIndexBenchmark: test for loading bloom filters directly from parquet files and
   loading bloom filters from metadata table based bloom index.

 - MetadataTableTestSuiteJob: Test for reading records directly from HBase HFile.

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
